### PR TITLE
Add disclaimer about language server complexity

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,22 @@ Development of this project requires [Node.js _v14.x_](https://nodejs.org) and
 [yarn _v1.x_](https://classic.yarnpkg.com/).
 
 Developing the `klighd-vscode` extension requires an extension that has a dependency on
-`klighd-vscode` and provides a language client with KLighD synthesis capabilities. A good candidate
-for development is the `kieler.keith-vscode`
+`klighd-vscode` and provides a language client with [KLighD](https://github.com/kieler/KLighD)
+synthesis capabilities. A good candidate for development is the `kieler.keith-vscode`
 ([under development](https://git.rtsys.informatik.uni-kiel.de/projects/KIELER/repos/keith/browse?at=cfr/monorepo-restructure))
 extension.
 
-Furthermore, development of the `klighd-cli` requires a language server with KLighD synthesis
-capabilities. The server can either be started separately, using a socket for communication, or
-placed as a jar named `language-server.jar` in the _applications/klighd-cli_ folder.
+Furthermore, development of the `klighd-cli` requires a language server with
+[KLighD](https://github.com/kieler/KLighD) synthesis capabilities. The server can either be started
+separately, using a socket for communication, or placed as a jar named `language-server.jar` in the
+_applications/klighd-cli_ folder.
+
+#### Disclaimer
+
+Developing a language server that uses [KLighD](https://github.com/kieler/KLighD) to fulfill all
+requirements to be usable with these clients is no easy tasks. Until the distribution of
+[KLighD](https://github.com/kieler/KLighD) and documentation about building your own language server
+is improved, feel free to seek advise from a member of the KIELER working group.
 
 ### Scripts
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ is improved, feel free to seek advice from a member of the KIELER working group.
 An example for a simple language server with KLighD synthesis support can be found
 [here](https://github.com/kieler/osgiviz/tree/master/plugins/de.cau.cs.kieler.osgiviz.language.server).
 Configuration for the build process using Maven Tycho can be found
-[here](https://github.com/kieler/osgiviz/tree/master/plugins/de.cau.cs.kieler.osgiviz.language.server).
+[here](https://github.com/kieler/osgiviz/tree/master/build/de.cau.cs.kieler.osgiviz.language.server.cli).
 The VS Code extension for this language server can be found
 [here](https://github.com/kieler/osgiviz/tree/master/extension/osgiviz).
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ requirements to be usable with these clients is no easy tasks. Until the distrib
 [KLighD](https://github.com/kieler/KLighD) and documentation about building your own language server
 is improved, feel free to seek advise from a member of the KIELER working group.
 
+An example for a simple language server with KLighD synthesis support can be found
+[here](https://github.com/kieler/osgiviz/tree/master/plugins/de.cau.cs.kieler.osgiviz.language.server).
+Configuration for the build process using Maven Tycho can be found
+[here](https://github.com/kieler/osgiviz/tree/master/plugins/de.cau.cs.kieler.osgiviz.language.server).
+The VS Code extension for this language server can be found
+[here](https://github.com/kieler/osgiviz/tree/master/extension/osgiviz).
+
 ### Scripts
 
 > All scripts that are available at the monorepo root. Run a script with `yarn <script>`. More

--- a/applications/klighd-vscode/README.md
+++ b/applications/klighd-vscode/README.md
@@ -21,6 +21,13 @@ Instead, it should be used as a dependency by other extensions to easily support
 visualization with KLighD. Your host extension is responsible for configuring a language client,
 while the KLighD extension handles everything related to diagrams.
 
+### Disclaimer
+
+Developing a language server for your extension that uses [KLighD](https://github.com/kieler/KLighD)
+to fulfill all requirements to be usable with this extension is no easy tasks. Until the distribution of
+[KLighD](https://github.com/kieler/KLighD) and documentation about building your own language server
+is improved, feel free to seek advise from a member of the KIELER working group.
+
 ### Usage in your extension
 
 1. Add an extension dependency to your extension's `package.json`.

--- a/applications/klighd-vscode/README.md
+++ b/applications/klighd-vscode/README.md
@@ -28,6 +28,13 @@ to fulfill all requirements to be usable with this extension is no easy tasks. U
 [KLighD](https://github.com/kieler/KLighD) and documentation about building your own language server
 is improved, feel free to seek advise from a member of the KIELER working group.
 
+An example for a simple language server with KLighD synthesis support can be found
+[here](https://github.com/kieler/osgiviz/tree/master/plugins/de.cau.cs.kieler.osgiviz.language.server).
+Configuration for the build process using Maven Tycho can be found
+[here](https://github.com/kieler/osgiviz/tree/master/plugins/de.cau.cs.kieler.osgiviz.language.server).
+The VS Code extension for this language server can be found
+[here](https://github.com/kieler/osgiviz/tree/master/extension/osgiviz).
+
 ### Usage in your extension
 
 1. Add an extension dependency to your extension's `package.json`.

--- a/applications/klighd-vscode/README.md
+++ b/applications/klighd-vscode/README.md
@@ -31,7 +31,7 @@ is improved, feel free to seek advice from a member of the KIELER working group.
 An example for a simple language server with KLighD synthesis support can be found
 [here](https://github.com/kieler/osgiviz/tree/master/plugins/de.cau.cs.kieler.osgiviz.language.server).
 Configuration for the build process using Maven Tycho can be found
-[here](https://github.com/kieler/osgiviz/tree/master/plugins/de.cau.cs.kieler.osgiviz.language.server).
+[here](https://github.com/kieler/osgiviz/tree/master/build/de.cau.cs.kieler.osgiviz.language.server.cli).
 The VS Code extension for this language server can be found
 [here](https://github.com/kieler/osgiviz/tree/master/extension/osgiviz).
 

--- a/applications/klighd-vscode/package.json
+++ b/applications/klighd-vscode/package.json
@@ -2,7 +2,7 @@
     "name": "klighd-vscode",
     "displayName": "KLighD Diagrams",
     "description": "KLighD diagram support for Visual Studio Code",
-    "version": "0.0.1",
+    "version": "0.1.0",
     "publisher": "kieler",
     "author": "Kiel University <rt-kieler-devel@informatik.uni-kiel.de>",
     "icon": "icon.png",


### PR DESCRIPTION
Adds a small disclaimer to the root README and extension README to inform the user about the complexity of building a KLighD powered language server.

This has been an advice by @a-sr since it is quite complex to build a language server. Users that want to integrate the extension might not be aware of that.