### PR TITLE
Core: Fix layout used by text input options (#10)

### DIFF
--- a/packages/klighd-core/src/options/components/option-inputs.tsx
+++ b/packages/klighd-core/src/options/components/option-inputs.tsx
@@ -108,7 +108,7 @@ export function TextOption(props: TextOptionProps): VNode {
         <div classNames="options__column">
             <label htmlFor={props.id}>{props.name}</label>
             <input
-                classNames="options__input"
+                classNames="options__input options__text-field"
                 type="text"
                 id={props.id}
                 value={props.value}

--- a/packages/klighd-core/src/options/components/option-inputs.tsx
+++ b/packages/klighd-core/src/options/components/option-inputs.tsx
@@ -105,7 +105,8 @@ type TextOptionProps = BaseProps<string>;
 /** Renders a labeled text input. */
 export function TextOption(props: TextOptionProps): VNode {
     return (
-        <label htmlFor={props.id}>
+        <div classNames="options__column">
+            <label htmlFor={props.id}>{props.name}</label>
             <input
                 classNames="options__input"
                 type="text"
@@ -113,8 +114,7 @@ export function TextOption(props: TextOptionProps): VNode {
                 value={props.value}
                 on-change={(e: any) => props.onChange(e.target.value)}
             />
-            {props.name}
-        </label>
+        </div>
     );
 }
 

--- a/packages/klighd-core/styles/options.css
+++ b/packages/klighd-core/styles/options.css
@@ -126,6 +126,27 @@
     vertical-align: baseline;
 }
 
+.options__text-field {
+    padding: 2px 4px;
+    font-size: 1rem;
+
+    border: 2px solid var(--kdc-color-sidebar-trigger-background-hover);
+    border-radius: var(--kdc-border-radius-default);
+    background: var(--kdc-color-sidebar-trigger-background-active);
+    color: var(--kdc-color-sidebar-font-primary);
+}
+
+.options__text-field:focus,
+.options__text-field:focus-visible {
+    /* 
+    Text Field should use their border as their focus indicator. Without "!important"
+    the rule for all inputs ".options__input:focus-visible" takes precedence when the
+    styles are applied.
+    */
+    outline: none !important;
+    border-color: var(--kdc-color-primary);
+}
+
 /* Dont' show outlines when a user interacts with different options... */
 .options__input,
 .options__category > summary,
@@ -147,7 +168,8 @@
 
 .options__selection {
     padding: 4px 6px;
-    border-width: 2px;
+
+    border: 2px solid var(--kdc-color-sidebar-trigger-background-hover);
     border-radius: var(--kdc-border-radius-default);
     background: var(--kdc-color-sidebar-trigger-background-active);
     color: var(--kdc-color-sidebar-font-primary);


### PR DESCRIPTION
This fixes the issues identified in #10. Text inputs now use a vertical layout with the label placed on top. Furthermore, they are styled using the available theme, similar to the synthesis selector.

The issue (#10) contains a screenshot from before the fix. After the fix:
![image](https://user-images.githubusercontent.com/23103835/129243615-d113e783-698d-4cfd-9929-e69a1309b4ca.png)

closes #10