### PR TITLE
klighd-vscode: add dispatch-action command for other extensions

### DIFF
--- a/applications/klighd-vscode/README.md
+++ b/applications/klighd-vscode/README.md
@@ -125,14 +125,14 @@ vscode.commands.executeCommand("klighd-vscode.addActionHandler", refId: string, 
 ### Dispatching Actions
 
 The KLighD diagram extension provides the ability to send an action to all open diagram views that
-belong to the host extension. The action will be handled by the diagram core and potentially send to
+belong to the host extension. The action will be handled by the diagram core and potentially sent to
 the language server if it is handled that way.
 
 To send an action to a `klighd-vscode` webview, execute the following command:
 
 ```typescript
 // - refId: your registration id returned from the setLanguageClient command
-// - action: a valid Sprotty action that is send to open diagram views.
+// - action: a valid Sprotty action that is sent to open diagram views.
 vscode.commands.executeCommand("klighd-vscode.dispatchAction", refId: string, action: Action);
 ```
 

--- a/applications/klighd-vscode/README.md
+++ b/applications/klighd-vscode/README.md
@@ -24,9 +24,9 @@ while the KLighD extension handles everything related to diagrams.
 ### Disclaimer
 
 Developing a language server for your extension that uses [KLighD](https://github.com/kieler/KLighD)
-to fulfill all requirements to be usable with this extension is no easy task. Until the distribution of
-[KLighD](https://github.com/kieler/KLighD) and documentation about building your own language server
-is improved, feel free to seek advice from a member of the KIELER working group.
+to fulfill all requirements to be usable with this extension is no easy task. Until the distribution
+of [KLighD](https://github.com/kieler/KLighD) and documentation about building your own language
+server is improved, feel free to seek advice from a member of the KIELER working group.
 
 An example for a simple language server with KLighD synthesis support can be found
 [here](https://github.com/kieler/osgiviz/tree/master/plugins/de.cau.cs.kieler.osgiviz.language.server).
@@ -100,7 +100,7 @@ export async function activate(context: vscode.ExtensionContext) {
 }
 ```
 
-### Intercepting messages
+### Intercepting Messages
 
 The KLighD diagram extension provides the option to intercept diagram actions that are about to be
 sent to the language server. Each action has an identifier named `kind`.
@@ -122,10 +122,25 @@ To register your action handler with the `klighd-vscode` extension call the foll
 vscode.commands.executeCommand("klighd-vscode.addActionHandler", refId: string, kind: string, handler: ActionHandler);
 ```
 
+### Dispatching Actions
+
+The KLighD diagram extension provides the ability to send an action to all open diagram views that
+belong to the host extension. The action will be handled by the diagram core and potentially send to
+the language server if it is handled that way.
+
+To send an action to a `klighd-vscode` webview, execute the following command:
+
+```typescript
+// - refId: your registration id returned from the setLanguageClient command
+// - action: a valid Sprotty action that is send to open diagram views.
+vscode.commands.executeCommand("klighd-vscode.dispatchAction", refId: string, action: Action);
+```
+
 ## Known Issues
 
 -   Currently, only at most one extension that depends on `kieler.klighd-vscode` can be activated at
     the same time. This causes problems if a workspace opens multiple files that are handled by
-    different KLighD dependent extensions. This issue is tracked [here](https://github.com/kieler/klighd-vscode/issues/6).
+    different KLighD dependent extensions. This issue is tracked
+    [here](https://github.com/kieler/klighd-vscode/issues/6).
 -   Exported SVG are currently not displayed properly. This issue is tracked
     [here](https://github.com/eclipse/sprotty/issues/149).

--- a/applications/klighd-vscode/src/constants.ts
+++ b/applications/klighd-vscode/src/constants.ts
@@ -42,6 +42,7 @@ const withPrefix = (name: string) => `${extensionId}.${name}`;
 export const command = {
     setLanguageClient: withPrefix("setLanguageClient"),
     addActionHandler: withPrefix("addActionHandler"),
+    dispatchAction: withPrefix("dispatchAction"),
     clearData: withPrefix("data.clear"),
     // The following commands are registered by `sprotty-vscode`
     diagramOpen: withPrefix("diagram.open"),

--- a/applications/klighd-vscode/src/extension.ts
+++ b/applications/klighd-vscode/src/extension.ts
@@ -23,6 +23,7 @@ import { ActionHandlerCallback, KLighDExtension } from "./klighd-extension";
 import { LspHandler } from "./lsp-handler";
 import { StorageService } from "./storage/storage-service";
 import { ReportChangeMessage } from "./storage/messages";
+import { Action, isAction } from "sprotty-vscode-protocol";
 
 // potential exports for other extensions to improve their dev experience
 // Currently, this only includes our command string. Requires this extension to be published as a package.
@@ -112,6 +113,27 @@ export function activate(context: vscode.ExtensionContext): void {
                 extension.addActionHandler(kind, actionHandler);
             }
         )
+    );
+
+    // Command provided for other extensions to dispatch an action if a webview is open
+    context.subscriptions.push(
+        vscode.commands.registerCommand(command.dispatchAction, (id: string, action: Action) => {
+            const extension = extensionMap.get(id);
+            if (!extension) {
+                vscode.window.showErrorMessage(
+                    `${command.dispatchAction} command called with unknown reference id: ${id}`
+                );
+                return;
+            }
+
+            if (!isAction(action)) {
+                vscode.window.showErrorMessage(
+                    `${command.addActionHandler} command called with invalid arguments. Please refer to the documentation for reference about the correct usage.`
+                );
+            }
+
+            extension.webviews.forEach((webview) => webview.dispatch(action));
+        })
     );
 }
 

--- a/applications/klighd-vscode/src/extension.ts
+++ b/applications/klighd-vscode/src/extension.ts
@@ -108,6 +108,7 @@ export function activate(context: vscode.ExtensionContext): void {
                     vscode.window.showErrorMessage(
                         `${command.addActionHandler} command called with invalid arguments. Please refer to the documentation for reference about the correct usage.`
                     );
+                    return;
                 }
 
                 extension.addActionHandler(kind, actionHandler);
@@ -130,6 +131,7 @@ export function activate(context: vscode.ExtensionContext): void {
                 vscode.window.showErrorMessage(
                     `${command.addActionHandler} command called with invalid arguments. Please refer to the documentation for reference about the correct usage.`
                 );
+                return;
             }
 
             extension.webviews.forEach((webview) => webview.dispatch(action));


### PR DESCRIPTION
This PR adds a new command to the `klighd-vscode` extension that allows other extensions to dispatch an Sprotty action in all open webviews that belong to the host extension.

Usage (documented in the README as well):
```typescript
// - refId: your registration id returned from the setLanguageClient command
// - action: a valid Sprotty action that is send to open diagram views.
vscode.commands.executeCommand("klighd-vscode.dispatchAction", refId: string, action: Action);
```