### PR TITLE
fix(klighd-vscode): sync with editor is not toggled

### DIFF
--- a/applications/klighd-vscode/src/klighd-extension.ts
+++ b/applications/klighd-vscode/src/klighd-extension.ts
@@ -227,17 +227,15 @@ export class KLighDExtension extends SprottyLspVscodeExtension {
         this.context.subscriptions.push(
             commands.registerCommand(command.diagramSync, () => {
                 const activeWebview = this.findActiveWebview();
-                if (activeWebview && "toggleEditorSync" in activeWebview) {
-                    (activeWebview as KLighDWebview).setSyncWithEditor(true);
-                }
+
+                (activeWebview as KLighDWebview)?.setSyncWithEditor?.(true);
             })
         );
         this.context.subscriptions.push(
             commands.registerCommand(command.diagramNoSync, () => {
                 const activeWebview = this.findActiveWebview();
-                if (activeWebview && "toggleEditorSync" in activeWebview) {
-                    (activeWebview as KLighDWebview).setSyncWithEditor(false);
-                }
+
+                (activeWebview as KLighDWebview)?.setSyncWithEditor?.(false);
             })
         );
     }


### PR DESCRIPTION
A rename proposed for #13 caused this problem, since "in" checks are not correctly refactored.

This PR also removes the "in" checks and just calls the method if it exists on the object.