### PR TITLE
Node titles allow for any rendering, not only KTexts

### DIFF
--- a/packages/klighd-core/src/depth-map.ts
+++ b/packages/klighd-core/src/depth-map.ts
@@ -18,7 +18,7 @@
 import { KGraphElement, KNode } from "@kieler/klighd-interactive/lib/constraint-classes";
 import { Point, SChildElement, SModelRoot, Viewport } from "sprotty";
 import { RenderOptionsRegistry, FullDetailRelativeThreshold, FullDetailScaleThreshold } from "./options/render-options-registry";
-import { KContainerRendering, K_RECTANGLE } from "./skgraph-models";
+import { isContainerRendering, isRendering, KRendering } from "./skgraph-models";
 
 /**
  * The possible detail level of a KNode as determined by the DepthMap
@@ -185,7 +185,8 @@ export class DepthMap {
 
             entry = { containingRegion: parentEntry.providingRegion ?? parentEntry.containingRegion, providingRegion: undefined }
 
-            if (element.data.length > 0 && element.data[0].type == K_RECTANGLE && (element.data[0] as KContainerRendering).children[0] && element instanceof KNode) {
+            const kRendering = this.findRendering(element)
+            if (element instanceof KNode && kRendering && isContainerRendering(kRendering) && kRendering.children.length !== 0) {
 
                 entry = { containingRegion: entry.containingRegion, providingRegion: new Region(element) }
 
@@ -220,6 +221,22 @@ export class DepthMap {
 
         this.regionIndexMap.set(element.id, entry)
         return entry
+    }
+    
+    /**
+     * Finds the KRendering in the given graph element.
+     * @param element The graph element to look up the rendering for.
+     * @returns The KRendering.
+     */
+    findRendering(element: KGraphElement): KRendering | undefined {
+        for (const data of element.data) {
+            if (data === null)
+                continue
+            if (isRendering(data)) {
+                return data
+            }
+        }
+        return undefined
     }
 
     public getContainingRegion(element: SChildElement & KGraphElement, viewport: Viewport, renderOptions: RenderOptionsRegistry): Region | undefined {

--- a/packages/klighd-core/src/options/render-options-registry.ts
+++ b/packages/klighd-core/src/options/render-options-registry.ts
@@ -54,7 +54,7 @@ export class UseSmartZoom implements RenderOption {
 export class FullDetailRelativeThreshold implements RangeOption {
     static readonly ID: string = 'full-detail-relative-threshold'
     static readonly NAME: string = 'Full Detail Relative Threshold'
-    static readonly DEFAULT: number = 0.2
+    static readonly DEFAULT: number = 0.15
     readonly id: string = FullDetailRelativeThreshold.ID
     readonly name: string = FullDetailRelativeThreshold.NAME
     readonly type: TransformationOptionType = TransformationOptionType.RANGE

--- a/packages/klighd-core/src/skgraph-models.ts
+++ b/packages/klighd-core/src/skgraph-models.ts
@@ -114,6 +114,11 @@ export interface KRendering extends KGraphData, KStyleHolder {
      * A possible tooltip that can be shown for this rendering.
      */
     tooltip?: string
+
+    /**
+     * Whether the server pre-determined this KRendering to be the title of a node or not. 
+     */
+    isNodeTitle?: boolean
     /**
      * The unique identifier of this rendering.
      */
@@ -250,11 +255,6 @@ export interface KText extends KRendering {
      * The server pre-calculated line heights for each individual line.
      */
     calculatedTextLineHeights?: number[]
-
-    /**
-     * Whether the server pre-determined this KText to be the title of a node or not. 
-     */
-    isNodeTitle: boolean
 }
 
 /**

--- a/packages/klighd-core/src/views-common.ts
+++ b/packages/klighd-core/src/views-common.ts
@@ -425,8 +425,8 @@ export function findTextBoundsAndTransformationData(rendering: KText, styles: KS
             const foundBounds = rendering.calculatedBounds
             bounds.x = calculateX(foundBounds.x, foundBounds.width, styles.kHorizontalAlignment, textWidth)
             bounds.y = calculateY(foundBounds.y, foundBounds.height, styles.kVerticalAlignment, lines)
-            bounds.width = foundBounds.width
-            bounds.height = foundBounds.height
+            bounds.width = textWidth
+            bounds.height = textHeight
         }
         // if no bounds have been found yet, they should be in the boundsMap
         if (bounds.x === undefined && context.boundsMap !== undefined) {
@@ -434,8 +434,8 @@ export function findTextBoundsAndTransformationData(rendering: KText, styles: KS
             if (bounds !== undefined) {
                 bounds.x = calculateX(foundBounds.x, foundBounds.width, styles.kHorizontalAlignment, textWidth)
                 bounds.y = calculateY(foundBounds.y, foundBounds.height, styles.kVerticalAlignment, lines)
-                bounds.width = foundBounds.width
-                bounds.height = foundBounds.height
+                bounds.width = textWidth
+                bounds.height = textHeight
             }
         }
         // If there is a decoration, calculate the bounds and decoration (containing a possible rotation) from that.

--- a/packages/klighd-core/src/views-common.ts
+++ b/packages/klighd-core/src/views-common.ts
@@ -19,7 +19,7 @@ import { Bounds, Point, toDegrees } from 'sprotty/lib';
 import { SKGraphModelRenderer } from './skgraph-model-renderer';
 import {
     Decoration, HorizontalAlignment, KColoring, KHorizontalAlignment, KLineCap, KLineJoin, KLineStyle, KPolyline, KPosition, KRendering,
-    KRotation, KText, KTextUnderline, KVerticalAlignment, LineCap, LineJoin, LineStyle, SKEdge, SKGraphElement, SKNode, Underline, VerticalAlignment
+    KRotation, KText, KTextUnderline, KVerticalAlignment, K_TEXT, LineCap, LineJoin, LineStyle, SKEdge, SKGraphElement, SKLabel, SKNode, Underline, VerticalAlignment
 } from './skgraph-models';
 import { KStyles, ColorStyle } from './views-styles';
 
@@ -308,10 +308,17 @@ export function camelToKebab(string: string): string {
  * @param kRotation The KRotation style of the rendering.
  * @param parent The parent SKGraphElement this rendering is contained in.
  * @param context The rendering context used to render this element.
+ * @param boundingBox If this method should not return the values to be applied to the SVG but the
+ *  box coordinates instead. Required to find the true bounding box of text renderings.
  * @param isEdge If the rendering is for an edge.
  */
-export function findBoundsAndTransformationData(rendering: KRendering, kRotation: KRotation | undefined, parent: SKGraphElement,
-    context: SKGraphModelRenderer, isEdge?: boolean): BoundsAndTransformation | undefined {
+export function findBoundsAndTransformationData(rendering: KRendering, styles: KStyles, parent: SKGraphElement,
+    context: SKGraphModelRenderer, isEdge?: boolean, boundingBox?: boolean): BoundsAndTransformation | undefined {
+    
+    if (rendering.type === K_TEXT && !boundingBox) {
+        return findTextBoundsAndTransformationData(rendering as KText, styles, parent, context)
+    }
+
     let bounds
     let decoration
 
@@ -369,7 +376,7 @@ export function findBoundsAndTransformationData(rendering: KRendering, kRotation
     }
 
     // Calculate the svg transformation function string for this element and all its child elements given the bounds and decoration.
-    const transformation = getTransformation(bounds, decoration, kRotation, isEdge)
+    const transformation = getTransformation(bounds, decoration, styles.kRotation, isEdge)
 
     return {
         bounds: bounds,
@@ -383,9 +390,8 @@ export function findBoundsAndTransformationData(rendering: KRendering, kRotation
  * @param styles The styles for this text rendering
  * @param parent The parent SKGraphElement this rendering is contained in.
  * @param context The rendering context used to render this element.
- * @param lines The number of lines the text rendering spans across.
  */
-export function findTextBoundsAndTransformationData(rendering: KText, styles: KStyles, parent: SKGraphElement, context: SKGraphModelRenderer, lines: number) { // eslint-disable-line
+export function findTextBoundsAndTransformationData(rendering: KText, styles: KStyles, parent: SKGraphElement | SKLabel, context: SKGraphModelRenderer): BoundsAndTransformation | undefined {
     let bounds: {
         x: number | undefined,
         y: number | undefined,
@@ -398,6 +404,19 @@ export function findTextBoundsAndTransformationData(rendering: KText, styles: KS
         height: undefined
     }
     let decoration
+
+    // Find the text to write first.
+    let text = undefined
+    // KText elements as renderings of labels have their text in the KLabel, not the KText
+    if ('text' in parent) { // if parent is KLabel
+        text = parent.text
+    } else {
+        text = rendering.text
+    }
+
+    // The text split into an array for each individual line
+    const lines = text?.split('\n')?.length ?? 1
+
     if (rendering.calculatedTextBounds !== undefined) {
         const textWidth = rendering.calculatedTextBounds.width
         const textHeight = rendering.calculatedTextBounds.height
@@ -464,7 +483,7 @@ export function findTextBoundsAndTransformationData(rendering: KText, styles: KS
     // Calculate the svg transformation function string for this element given the bounds and decoration.
     const transformation = getTransformation(bounds as Bounds, decoration, styles.kRotation, false, true)
     return {
-        bounds: bounds,
+        bounds: bounds as Bounds,
         transformation: transformation
     }
 }

--- a/packages/klighd-core/src/views-rendering.tsx
+++ b/packages/klighd-core/src/views-rendering.tsx
@@ -24,11 +24,11 @@ import { DetailLevel } from './depth-map';
 import { PaperShadows, SimplifySmallText, TextSimplificationThreshold, TitleScalingFactor, TitleOverlayThreshold } from './options/render-options-registry';
 import { SKGraphModelRenderer } from './skgraph-model-renderer';
 import {
-    Arc, isRendering, KArc, KChildArea, KContainerRendering, KForeground, KImage, KPolyline, KRendering, KRenderingLibrary, KRenderingRef, KRoundedBendsPolyline,
-    KRoundedRectangle, KShadow, KText, K_ARC, K_CHILD_AREA, K_CONTAINER_RENDERING, K_CUSTOM_RENDERING, K_ELLIPSE, K_IMAGE, K_POLYGON, K_POLYLINE, K_RECTANGLE, K_RENDERING_LIBRARY,
-    K_RENDERING_REF, K_ROUNDED_BENDS_POLYLINE, K_ROUNDED_RECTANGLE, K_SPLINE, K_TEXT, SKEdge, SKGraphElement, SKLabel, SKNode
+    Arc, HorizontalAlignment, isRendering, KArc, KChildArea, KContainerRendering, KForeground, KHorizontalAlignment, KImage, KPolyline, KRendering, KRenderingLibrary, KRenderingRef, KRoundedBendsPolyline,
+    KRoundedRectangle, KShadow, KText, KVerticalAlignment, K_ARC, K_CHILD_AREA, K_CONTAINER_RENDERING, K_CUSTOM_RENDERING, K_ELLIPSE, K_IMAGE, K_POLYGON, K_POLYLINE, K_RECTANGLE, K_RENDERING_LIBRARY,
+    K_RENDERING_REF, K_ROUNDED_BENDS_POLYLINE, K_ROUNDED_RECTANGLE, K_SPLINE, K_TEXT, SKEdge, SKGraphElement, SKLabel, SKNode, VerticalAlignment
 } from './skgraph-models';
-import { findBoundsAndTransformationData, findTextBoundsAndTransformationData, getPoints } from './views-common';
+import { BoundsAndTransformation, calculateX, findBoundsAndTransformationData, getPoints } from './views-common';
 import {
     ColorStyles, DEFAULT_CLICKABLE_FILL, DEFAULT_FILL, getKStyles, getSvgColorStyle, getSvgColorStyles, getSvgLineStyles, getSvgShadowStyles, getSvgTextStyles, isInvisible,
     KStyles, LineStyles
@@ -66,21 +66,14 @@ export function renderChildArea(rendering: KChildArea, parent: SKGraphElement, p
  * @param propagatedStyles The styles propagated from parent elements that should be taken into account.
  * @param context The rendering context for this element.
  */
-export function renderRectangularShape(rendering: KContainerRendering, parent: SKGraphElement, propagatedStyles: KStyles,
-    context: SKGraphModelRenderer, mListener: KlighdInteractiveMouseListener): VNode {
-    // The styles that should be propagated to the children of this rendering. Will be modified in the getKStyles call.
-    const stylesToPropagate = new KStyles
-    // Extract the styles of the rendering into a more presentable object.
-    const styles = getKStyles(parent, rendering.styles, propagatedStyles, stylesToPropagate)
-
-    // Determine the bounds of the rendering first and where it has to be placed.
-    const boundsAndTransformation = findBoundsAndTransformationData(rendering, styles.kRotation, parent, context)
-    // Add the transformations to be able to positon the title correctly and above other elements
-    context.positions[context.positions.length - 1] += (boundsAndTransformation?.transformation ?? "")
-    if (boundsAndTransformation === undefined) {
-        // If no bounds are found, the rendering can not be drawn.
-        return renderError(rendering)
-    }
+export function renderRectangularShape(
+    rendering: KContainerRendering,
+    parent: SKGraphElement,
+    boundsAndTransformation: BoundsAndTransformation,
+    styles: KStyles,
+    stylesToPropagate: KStyles,
+    context: SKGraphModelRenderer,
+    mListener: KlighdInteractiveMouseListener): VNode {
 
     const gAttrs = {
         ...(boundsAndTransformation.transformation !== undefined ? { transform: boundsAndTransformation.transformation } : {})
@@ -245,21 +238,13 @@ export function renderRectangularShape(rendering: KContainerRendering, parent: S
  * @param propagatedStyles The styles propagated from parent elements that should be taken into account.
  * @param context The rendering context for this element.
  */
-export function renderLine(rendering: KPolyline, parent: SKGraphElement | SKEdge, propagatedStyles: KStyles,
-    context: SKGraphModelRenderer, mListener: KlighdInteractiveMouseListener): VNode {
-    // The styles that should be propagated to the children of this rendering. Will be modified in the getKStyles call.
-    const stylesToPropagate = new KStyles
-
-    // Extract the styles of the rendering into a more presentable object.
-    const styles = getKStyles(parent, rendering.styles, propagatedStyles, stylesToPropagate)
-
-    // Determine the bounds of the rendering first and where it has to be placed.
-    // TODO: KPolylines are a special case of container renderings: their bounds should not be given down to their child renderings.
-    const boundsAndTransformation = findBoundsAndTransformationData(rendering, styles.kRotation, parent, context, true)
-    if (boundsAndTransformation === undefined) {
-        // If no bounds are found, the rendering can not be drawn.
-        return renderError(rendering)
-    }
+export function renderLine(rendering: KPolyline,
+    parent: SKGraphElement | SKEdge,
+    boundsAndTransformation: BoundsAndTransformation,
+    styles: KStyles,
+    stylesToPropagate: KStyles,
+    context: SKGraphModelRenderer,
+    mListener: KlighdInteractiveMouseListener): VNode {
 
     const gAttrs = {
         ...(boundsAndTransformation.transformation !== undefined ? { transform: boundsAndTransformation.transformation } : {})
@@ -388,8 +373,12 @@ export function renderLine(rendering: KPolyline, parent: SKGraphElement | SKEdge
  * @param context The rendering context for this element.
  * @param mListener The mouse listener.
  */
-export function renderKText(rendering: KText, parent: SKGraphElement | SKLabel, propagatedStyles: KStyles,
-    context: SKGraphModelRenderer, mListener: KlighdInteractiveMouseListener): VNode {
+export function renderKText(rendering: KText,
+    parent: SKGraphElement | SKLabel,
+    boundsAndTransformation: BoundsAndTransformation,
+    styles: KStyles,
+    context: SKGraphModelRenderer,
+    mListener: KlighdInteractiveMouseListener): VNode {
     // Find the text to write first.
     let text = undefined
     // KText elements as renderings of labels have their text in the KLabel, not the KText
@@ -404,15 +393,6 @@ export function renderKText(rendering: KText, parent: SKGraphElement | SKLabel, 
     // The text split into an array for each individual line
     const lines = text.split('\n')
 
-    // Extract the styles of the rendering into a more presentable object.
-    const styles = getKStyles(parent, rendering.styles, propagatedStyles)
-
-    // Determine the bounds of the rendering first and where it has to be placed.
-    const boundsAndTransformation = findTextBoundsAndTransformationData(rendering, styles, parent, context, lines.length)
-    if (boundsAndTransformation === undefined) {
-        // If no bounds are found, the rendering can not be drawn.
-        return renderError(rendering)
-    }
 
     // Check the invisibility first. If this rendering is supposed to be invisible, do not render it,
     // only render its children transformed by the transformation already calculated.
@@ -491,106 +471,12 @@ export function renderKText(rendering: KText, parent: SKGraphElement | SKLabel, 
             attrs.textLength = rendering.calculatedTextLineWidths[0]
             attrs.lengthAdjust = 'spacingAndGlyphs'
         }
-
-        const overlayThreshold = context.renderingOptions.getValueOrDefault(TitleOverlayThreshold)
-
-        if (context.depthMap) {
-            if (boundsAndTransformation.bounds.width && boundsAndTransformation.bounds.height && rendering.isNodeTitle) {
-
-                // Check whether or not the parent node is a child area.
-                // If the parent is a child area, the text is a title of the region.
-                // For macro states this is reached via explicit call to renderKText with the parent being the correct child area.
-                const region = context.depthMap.getProvidingRegion(parent as KNode, context.viewport, context.renderingOptions)
-                if (region) {
-                    if (region.detail !== DetailLevel.FullDetails && parent.children.length > 1
-                        || (rendering.calculatedTextBounds && rendering.calculatedTextBounds.height * context.viewport.zoom <= overlayThreshold)) {
-                        // Scale to limit of bounding box or max size.
-                        const titleScalingFactorOption = context.renderingOptions.getValueOrDefault(TitleScalingFactor)
-                        let maxScale = titleScalingFactorOption
-                        // Indentation used in the layouting in pixels.
-                        if (context.viewport) {
-                            maxScale = maxScale / context.viewport.zoom
-                        }
-                        const scaleX = (region.boundingRectangle.bounds.width - attrs.x) / boundsAndTransformation.bounds.width
-                        const scaleY = region.boundingRectangle.bounds.height / boundsAndTransformation.bounds.height
-                        let scalingFactor = scaleX > scaleY ? scaleY : scaleX
-                        // Don't let scalingfactor get too big.
-                        scalingFactor = scalingFactor > maxScale ? maxScale : scalingFactor
-                        // Make sure scalingfactor is not below 1.
-                        scalingFactor = scalingFactor > 1 ? scalingFactor : 1
-
-                        // Smooth transition between overlay title and normal title.
-                        if (rendering.calculatedTextBounds) {
-                            const t = Math.max((overlayThreshold - rendering.calculatedTextBounds.height * context.viewport.zoom), 0) / 3
-                            if (t <= 1) {
-                                scalingFactor = (1 - t) * 1 + t * scalingFactor
-                            }
-                        }
-                        // Set the indentation.
-                        attrs.x /= scalingFactor
-                        // Remove spacing to the left for region titles.
-                        boundsAndTransformation.transformation = `scale(${scalingFactor},${scalingFactor})`
-                        // Calculate exact height of title text
-                        region.regionTitleHeight = scalingFactor * (boundsAndTransformation.bounds.height)
-                        region.regionTitleIndentation = boundsAndTransformation.bounds.x ?? 0
-                    }
-                }
-                else {
-                    if (rendering.calculatedTextBounds && rendering.calculatedTextBounds.height * context.viewport.zoom <= overlayThreshold) {
-                        const titleScalingFactorOption = context.renderingOptions.getValueOrDefault(TitleScalingFactor)
-                        let maxScale = titleScalingFactorOption
-                        // Indentation used in the layouting in pixels.
-                        if (context.viewport) {
-                            maxScale = maxScale / context.viewport.zoom
-                        }
-                        const scaleX = ((parent as KNode).bounds.width - attrs.x) / boundsAndTransformation.bounds.width
-                        const scaleY = (parent as KNode).bounds.height / boundsAndTransformation.bounds.height
-                        let scalingFactor = scaleX > scaleY ? scaleY : scaleX
-                        // Don't let scalingfactor get too big.
-                        scalingFactor = scalingFactor > maxScale ? maxScale : scalingFactor
-                        // Make sure scalingfactor is not below 1.
-                        scalingFactor = scalingFactor > 1 ? scalingFactor : 1
-                        // Smooth transition between overlay title and normal title.
-                        if (rendering.calculatedTextBounds) {
-                            const t = (overlayThreshold - rendering.calculatedTextBounds.height * context.viewport.zoom) / 3
-                            if (t <= 1) {
-                                scalingFactor = (1 - t) * 1 + t * scalingFactor
-                            }
-                        }
-                        // Keep the scaled title centered by moving it to the left by the half of the growth in width.
-                        attrs.x -= (scalingFactor * boundsAndTransformation.bounds.width - boundsAndTransformation.bounds.width) / (2 * scalingFactor)
-
-                        // Remove spacing to the left for region titles.
-                        boundsAndTransformation.transformation = `scale(${scalingFactor},${scalingFactor})`
-                    }
-                }
-            }
-        }
-        // Draw white background for overlaying titles
-        if (context.depthMap && rendering.isNodeTitle && ((region && region.detail === DetailLevel.FullDetails) || !region)
-            && rendering.calculatedTextBounds && rendering.calculatedTextBounds.height * context.viewport.zoom <= overlayThreshold) {
-            // Adapt y value to place the rectangle on the top of the text. 
-            attrs.y -= (boundsAndTransformation.bounds.height ?? 0) / 2
-            // Adapt position of text in rectangle to place text in center
-            const attrs2 = { ...attrs }
-            attrs2.x += (boundsAndTransformation.bounds.width ?? 0) / 2
-            attrs2.y += (boundsAndTransformation.bounds.height ?? 0) / 2
-            attrs2.style["dominant-baseline"] = "middle"
-            attrs2.attrs = { "text-anchor": "middle" }
-            // Add a rectangle behind the title
-            elements = [
-                <rect x={attrs.x} y={attrs.y} width={boundsAndTransformation.bounds.width} height={boundsAndTransformation.bounds.height} fill="white" opacity="0.8" stroke="black"> </rect>,
-                <text {...attrs2}>
-                    {...lines}
-                </text>
-            ]
-        } else {
-            elements = [
-                <text {...attrs}>
-                    {...lines}
-                </text>
-            ]
-        }
+        
+        elements = [
+            <text {...attrs}>
+                {...lines}
+            </text>
+        ]
     } else {
         // Otherwise, put each line of text in a separate <text> element.
         const calculatedTextLineWidths = rendering.calculatedTextLineWidths
@@ -617,20 +503,10 @@ export function renderKText(rendering: KText, parent: SKGraphElement | SKLabel, 
     const gAttrs = {
         ...(boundsAndTransformation.transformation !== undefined ? { transform: boundsAndTransformation.transformation } : {})
     }
-    if (region || !rendering.isNodeTitle) {
-        // build the element from the above defined attributes and children
-        return <g id={rendering.renderingId} {...gAttrs}>
-            {...elements}
-        </g>
-    } else {
-        // Add the transformations necessary for correct placement
-        const positionOffset = context.positions[context.positions.length - 1]
-        gAttrs.transform = gAttrs.transform != undefined ? positionOffset + gAttrs.transform : positionOffset
-        context.titles[context.titles.length - 1].push(<g id={rendering.renderingId} {...gAttrs}>
-            {...elements}
-        </g>)
-        return <g></g>
-    }
+    // build the element from the above defined attributes and children
+    return <g id={rendering.renderingId} {...gAttrs}>
+        {...elements}
+    </g>
 }
 
 /**
@@ -987,16 +863,149 @@ export function getRendering(datas: KGraphData[], parent: SKGraphElement, propag
  * @param context The rendering context for this element.
  * @param mListener The mouse listener.
  */
-export function renderKRendering(kRendering: KRendering, parent: SKGraphElement, propagatedStyles: KStyles,
+export function renderKRendering(kRendering: KRendering, parent: SKGraphElement | SKLabel, propagatedStyles: KStyles,
     context: SKGraphModelRenderer, mListener: KlighdInteractiveMouseListener): VNode | undefined { // TODO: not all of these are implemented yet
 
+    // The styles that should be propagated to the children of this rendering. Will be modified in the getKStyles call.
+    const stylesToPropagate = new KStyles
+    // Extract the styles of the rendering into a more presentable object.
+    const styles = getKStyles(parent, kRendering.styles, propagatedStyles, stylesToPropagate)
+
+    // Determine the bounds of the rendering first and where it has to be placed.
+    const isEdge = [K_POLYLINE,  K_POLYGON, K_ROUNDED_BENDS_POLYLINE, K_SPLINE].includes(kRendering.type)
+    const boundsAndTransformation = findBoundsAndTransformationData(kRendering, styles, parent, context, isEdge)
+    if (boundsAndTransformation === undefined) {
+        // If no bounds are found, the rendering can not be drawn.
+        return renderError(kRendering)
+    }
+
+    const providingRegion = context.depthMap?.getProvidingRegion(parent as KNode, context.viewport, context.renderingOptions)
+
+    // Check if this is a title rendering. If we have a title, create that rendering, remember where it should be and how much space it has.
+    // If we are zoomed in far enough, return that rendering, otherwise put it into the list to be rendered on top by the element rendering.
+
+    // The rectangle that may be drawn behind the title rendering to highlight the overlay
+    let overlayRectangle: VNode | undefined = undefined
+    // remembers if this rendering is a title rendering and should therefore be rendered overlaying the other renderings.
+    let isOverlay = false
+    
+    // If this rendering is the main title rendering of the element, either render it usually if
+    // zoomed in far enough or remember it to be rendered later scaled up and overlayed on top of the parent rendering.
+    if (context.depthMap && boundsAndTransformation.bounds.width && boundsAndTransformation.bounds.height && kRendering.isNodeTitle) {
+        const overlayThreshold = context.renderingOptions.getValueOrDefault(TitleOverlayThreshold)
+        if (providingRegion && providingRegion.detail !== DetailLevel.FullDetails && parent.children.length > 1
+            || kRendering.calculatedBounds && kRendering.calculatedBounds.height * context.viewport.zoom <= overlayThreshold) {
+            isOverlay = true
+
+            let boundingBox = boundsAndTransformation.bounds
+            // For KTexts the x and y coordinates define the origin of the baseline, not the bounding box.
+            if (kRendering.type === K_TEXT) {
+                boundingBox = findBoundsAndTransformationData(kRendering, styles, parent, context, isEdge, true)?.bounds ?? boundingBox
+            }
+            
+            // Scale to limit of bounding box or max size.
+            const titleScalingFactorOption = context.renderingOptions.getValueOrDefault(TitleScalingFactor) as number
+            let maxScale = titleScalingFactorOption
+            if (context.viewport) {
+                maxScale = maxScale / context.viewport.zoom
+            }
+            const parentBounds = providingRegion ? providingRegion.boundingRectangle.bounds : (parent as KNode).bounds
+            const originalWidth = boundingBox.width
+            const originalHeight = boundingBox.height
+            const originalX = boundingBox.x
+            const originalY = boundingBox.y
+
+            const maxScaleX = parentBounds.width / originalWidth
+            const maxScaleY = parentBounds.height / originalHeight
+            // Don't let scalingfactor get too big.
+            let scalingFactor = Math.min(maxScaleX, maxScaleY, maxScale)
+            // Make sure we never scale down.
+            scalingFactor = Math.max(scalingFactor,  1)
+
+            // Smooth transition between overlay title and normal title.
+            const t = Math.max((overlayThreshold - boundingBox.height * context.viewport.zoom), 0) / 3
+            if (t <= 1) {
+                scalingFactor = 1 + t * scalingFactor - t
+            }
+            // Calculate the new x and y indentation:
+            // width required of scaled rendering
+            const newWidth = originalWidth * scalingFactor
+            // space to the left of the rendering without scaling...
+            const spaceL = originalX
+            // ...and to its right
+            const spaceR = parentBounds.width - originalX - originalWidth
+            // New x value after taking space off both sides at an equal ratio
+            const newX = originalX - spaceL * (newWidth - originalWidth) / (spaceL + spaceR)
+
+            // Same for y axis, just with switched dimensional variables.
+            const newHeight = originalHeight * scalingFactor
+            const spaceT = originalY
+            const spaceB = parentBounds.height - originalY - originalHeight
+            const newY = originalY - spaceT * (newHeight - originalHeight) / (spaceT + spaceB)
+
+            // Apply the new bounds and scaling as the element's transformation.
+            const translateAndScale = `translate(${newX},${newY})scale(${scalingFactor})`
+            if (!providingRegion) {
+                // Add the transformations necessary for correct placement
+                const positionOffset = context.positions[context.positions.length - 1]
+                boundsAndTransformation.transformation = positionOffset + translateAndScale
+            } else {
+                boundsAndTransformation.transformation = translateAndScale
+            }
+            // For text renderings, recalculate the required bounds the text needs with the updated data.
+            if (kRendering.type === K_TEXT && (kRendering as KText).calculatedTextBounds) {
+                const rendering = kRendering as KText
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                const textWidth = rendering.calculatedTextBounds!.width
+
+                // text centered in its new bounding box around local 0,0 coordinates
+                styles.kHorizontalAlignment = {
+                    horizontalAlignment: HorizontalAlignment.CENTER
+                } as KHorizontalAlignment
+                styles.kVerticalAlignment = {
+                    verticalAlignment: VerticalAlignment.CENTER
+                } as KVerticalAlignment
+                boundsAndTransformation.bounds = {
+                    x: calculateX(0, originalWidth, styles.kHorizontalAlignment, textWidth),
+                    y: originalHeight * 0.5,
+                    width: originalWidth,
+                    height: originalHeight
+                }
+            } else {
+                // Offsets are already applied in the transformation, so set them to 0 here.
+                boundsAndTransformation.bounds = {
+                    x: 0,
+                    y: 0,
+                    width: originalWidth,
+                    height: originalHeight
+                }
+            }
+            if (providingRegion) {
+                // Store exact height of title text
+                providingRegion.regionTitleHeight = newHeight
+                providingRegion.regionTitleIndentation = newX
+            }
+            // Draw white background for overlaying titles
+            if (context.depthMap && kRendering.isNodeTitle && ((providingRegion && providingRegion.detail === DetailLevel.FullDetails) || !providingRegion)
+                && kRendering.calculatedBounds && kRendering.calculatedBounds.height * context.viewport.zoom <= overlayThreshold
+                // Don't draw if the rendering is an empty KText
+                && (kRendering.type !== K_TEXT || (kRendering as KText).text !== "")) {
+                overlayRectangle = <rect x={0} y={0} width={originalWidth} height={originalHeight} fill="white" opacity="0.8" stroke="black"/>
+            }
+        }
+    }
+    // Add the transformations to be able to positon the title correctly and above other elements
+    context.positions[context.positions.length - 1] += (boundsAndTransformation?.transformation ?? "")
+
+    let svgRendering: VNode
     switch (kRendering.type) {
         case K_CONTAINER_RENDERING: {
             console.error('A rendering can not be a ' + kRendering.type + ' by itself, it needs to be a subclass of it.')
             return undefined
         }
         case K_CHILD_AREA: {
-            return renderChildArea(kRendering as KChildArea, parent, propagatedStyles, context)
+            svgRendering = renderChildArea(kRendering as KChildArea, parent, propagatedStyles, context)
+            break
         }
         case K_CUSTOM_RENDERING: {
             console.error('The rendering for ' + kRendering.type + ' is not implemented yet.')
@@ -1008,21 +1017,35 @@ export function renderKRendering(kRendering: KRendering, parent: SKGraphElement,
         case K_IMAGE:
         case K_RECTANGLE:
         case K_ROUNDED_RECTANGLE: {
-            return renderRectangularShape(kRendering as KContainerRendering, parent, propagatedStyles, context, mListener)
+            svgRendering = renderRectangularShape(kRendering as KContainerRendering, parent, boundsAndTransformation, styles, stylesToPropagate, context, mListener)
+            break
         }
         case K_POLYLINE:
         case K_POLYGON:
         case K_ROUNDED_BENDS_POLYLINE:
         case K_SPLINE: {
-            return renderLine(kRendering as KPolyline, parent, propagatedStyles, context, mListener)
+            svgRendering = renderLine(kRendering as KPolyline, parent, boundsAndTransformation, styles, stylesToPropagate, context, mListener)
+            break
         }
         case K_TEXT: {
-            return renderKText(kRendering as KText, parent, propagatedStyles, context, mListener)
+            svgRendering = renderKText(kRendering as KText, parent, boundsAndTransformation, styles, context, mListener)
+            break
         }
         default: {
             console.error('The rendering is of an unknown type:' + kRendering.type)
             return undefined
         }
+    }
+    // Put the rectangle for the overlay behind the rendering itself.
+    if (overlayRectangle) {
+        svgRendering.children?.unshift(overlayRectangle)
+    }
+    if (isOverlay) {
+        // Don't render this now if we have an overlay, but remember it to be put on top by the node rendering.
+        context.titles[context.titles.length - 1].push(svgRendering)
+        return <g></g>
+    } else {
+        return svgRendering
     }
 }
 


### PR DESCRIPTION
Initially node titles were implemented specific to KTexts, so that any KText could be a node title which would be scaled up within its parent rendering when zoomed out far enough to make that title illegible.
This PR rethinks the core idea and allows the same concept for any rendering. So now any rendering can be set to be the node title and that entire rendering (e.g. formatted text) will be scaled accordingly.

Also re-organizes some code used multiple times.