### PR TITLE
Adaption to Sprotty 0.11.1 and sprotty-vscode 0.2.0

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,7 +9,8 @@
     "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
     "rules": {
         "@typescript-eslint/no-explicit-any": "off",
-        "@typescript-eslint/ban-ts-comment": "off"
+        "@typescript-eslint/ban-ts-comment": "off",
+        "@typescript-eslint/no-namespace": "off"
     },
     "ignorePatterns": ["**/*.d.ts", "lib", "dist", "webpack.config.js"]
 }

--- a/applications/klighd-cli/package.json
+++ b/applications/klighd-cli/package.json
@@ -48,10 +48,11 @@
     "clean-webpack-plugin": "^4.0.0-alpha.0",
     "css-loader": "^5.2.4",
     "html-webpack-plugin": "4",
+    "file-loader": "6.2.0",
     "mini-css-extract-plugin": "^1.6.0",
     "npm-run-all": "^4.1.5",
     "pkg": "^5.1.0",
-    "ts-loader": "^8.2.0",
+    "ts-loader": "^8.0.3",
     "webpack": "^4.44.1",
     "webpack-cli": "^4.7.2"
   }

--- a/applications/klighd-cli/src/helpers.ts
+++ b/applications/klighd-cli/src/helpers.ts
@@ -15,7 +15,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-import { Viewport } from "sprotty";
+import { Viewport } from "sprotty-protocol";
 import { getBookmarkViewport as getViewport } from "@kieler/klighd-core";
 
 /** Returns a promise that resolves after a specific amount of milliseconds. */

--- a/applications/klighd-cli/src/main.ts
+++ b/applications/klighd-cli/src/main.ts
@@ -24,7 +24,7 @@ import {
     getActionDispatcher,
     SetPreferencesAction,
     bindServices,
-    SetInitialBookmark,
+    SetInitialBookmarkAction,
     Bookmark,
 } from "@kieler/klighd-core";
 import { getBookmarkViewport, getDiagramSourceUri, getLanguageId, readSearchParam, sleep } from "./helpers";
@@ -101,7 +101,7 @@ async function initDiagramView(sourceUri: string) {
 /** Communicates preferences to the diagram container which are read from the url search params. */
 function sendUrlSearchParamPreferences(actionDispatcher: ReturnType<typeof getActionDispatcher>) {
     actionDispatcher.dispatch(
-        new SetPreferencesAction({
+        SetPreferencesAction.create({
             resizeToFit: readSearchParam("resizeToFit") === "false" ? false : true,
         })
     );
@@ -112,7 +112,7 @@ function setInitialBookmark(actionDispatcher: ReturnType<typeof getActionDispatc
     const viewport = getBookmarkViewport();
     if (viewport) {
         actionDispatcher.dispatch(
-            new SetInitialBookmark(new Bookmark(viewport, "From URI"))
+            SetInitialBookmarkAction.create(new Bookmark(viewport, "From URI"))
         );
     }
 }

--- a/applications/klighd-cli/webpack.config.js
+++ b/applications/klighd-cli/webpack.config.js
@@ -44,6 +44,16 @@ module.exports = {
                 test: /\.css$/,
                 use: [MiniCssExtractPlugin.loader, "css-loader"],
             },
+            {
+                test: /\.(ttf)$/,
+                loader: 'file-loader',
+                options: {
+                    name: '[name].[ext]',
+                    outputPath: '',
+                    publicPath: '..',
+                    postTransformPublicPath: (p) => `__webpack_public_path__ + ${p}`,
+                }
+            },
         ],
     },
     plugins: [

--- a/applications/klighd-vscode/package.json
+++ b/applications/klighd-vscode/package.json
@@ -176,21 +176,22 @@
         "@types/node": "^12.11.7",
         "@types/vscode": "^1.56.0",
         "css-loader": "^5.2.4",
+        "file-loader": "6.2.0",
         "ovsx": "^0.2.0",
         "style-loader": "2.0.0",
         "ts-loader": "^8.0.14",
-        "typescript": "^4.1.3",
+        "typescript": "^4.3.0",
         "vsce": "^1.95.1",
         "webpack": "^4.44.1"
     },
     "dependencies": {
         "@kieler/klighd-core": "^0.2.1",
-        "inversify": "5.0.1",
+        "inversify": "^5.0.1",
         "nanoid": "^3.1.23",
         "reflect-metadata": "^0.1.13",
-        "sprotty": "0.9.0",
-        "sprotty-vscode": "^0.1.3",
-        "sprotty-vscode-webview": "^0.1.2",
+        "sprotty": "0.10.0",
+        "sprotty-vscode": "^0.1.4",
+        "sprotty-vscode-webview": "^0.1.4",
         "vscode-languageclient": "^5.2.1"
     }
 }

--- a/applications/klighd-vscode/package.json
+++ b/applications/klighd-vscode/package.json
@@ -194,9 +194,9 @@
         "inversify": "^5.0.1",
         "nanoid": "^3.1.23",
         "reflect-metadata": "^0.1.13",
-        "sprotty": "0.10.0",
-        "sprotty-vscode": "^0.1.4",
-        "sprotty-vscode-webview": "^0.1.4",
-        "vscode-languageclient": "^5.2.1"
+        "sprotty": "0.11.1",
+        "sprotty-vscode": "^0.2.0",
+        "sprotty-vscode-webview": "^0.2.0",
+        "vscode-languageclient": "^7.0.0"
     }
 }

--- a/applications/klighd-vscode/src-webview/klighd-widget.ts
+++ b/applications/klighd-vscode/src-webview/klighd-widget.ts
@@ -32,7 +32,7 @@ export class KlighdDiagramWidget extends VscodeDiagramWidget {
             await requestModel(this.actionDispatcher, this.diagramIdentifier.uri);
         } catch (err) {
             const status = new ServerStatusAction();
-            status.message = err instanceof Error ? err.message : err.toString();
+            status.message = err instanceof Error ? err.message : (err as any).toString();
             status.severity = "FATAL";
             this.setStatus(status);
         }

--- a/applications/klighd-vscode/src-webview/main.ts
+++ b/applications/klighd-vscode/src-webview/main.ts
@@ -31,7 +31,8 @@ import {
 import { DisabledKeyTool } from "sprotty-vscode-webview/lib/disabled-keytool";
 import { createKlighdDiagramContainer, bindServices } from "@kieler/klighd-core";
 import { MessageConnection } from "./message-connection";
-import { ActionMessage, isActionMessage, KeyTool } from "sprotty";
+import { KeyTool } from "sprotty";
+import { ActionMessage, isActionMessage } from "sprotty-protocol";
 import { KlighdDiagramWidget } from "./klighd-widget";
 import { MessagePersistenceStorage } from "./persistence-storage";
 

--- a/applications/klighd-vscode/src-webview/main.ts
+++ b/applications/klighd-vscode/src-webview/main.ts
@@ -20,6 +20,7 @@ import "reflect-metadata";
 import "sprotty-vscode-webview/css/sprotty-vscode.css";
 import "./main.css";
 import "@kieler/klighd-core/styles/main.css";
+import '@vscode/codicons/dist/codicon.css';
 
 import { Container } from "inversify";
 import {

--- a/applications/klighd-vscode/src-webview/main.ts
+++ b/applications/klighd-vscode/src-webview/main.ts
@@ -20,7 +20,6 @@ import "reflect-metadata";
 import "sprotty-vscode-webview/css/sprotty-vscode.css";
 import "./main.css";
 import "@kieler/klighd-core/styles/main.css";
-import '@vscode/codicons/dist/codicon.css';
 
 import { Container } from "inversify";
 import {

--- a/applications/klighd-vscode/src-webview/message-connection.ts
+++ b/applications/klighd-vscode/src-webview/message-connection.ts
@@ -17,7 +17,8 @@
 
 import { Connection, NotificationType } from "@kieler/klighd-core";
 import { inject, injectable } from "inversify";
-import { ActionMessage, isActionMessage, ServerStatusAction } from "sprotty";
+import { ServerStatusAction } from "sprotty";
+import { ActionMessage, isActionMessage } from "sprotty-protocol";
 import { VscodeDiagramWidgetFactory } from "sprotty-vscode-webview";
 import { vscodeApi } from "sprotty-vscode-webview/lib/vscode-api";
 

--- a/applications/klighd-vscode/src/extension.ts
+++ b/applications/klighd-vscode/src/extension.ts
@@ -17,13 +17,13 @@
 import "reflect-metadata";
 import { nanoid } from "nanoid/non-secure";
 import * as vscode from "vscode";
-import { LanguageClient } from "vscode-languageclient";
+import { CommonLanguageClient } from "vscode-languageclient";
 import { command } from "./constants";
 import { ActionHandlerCallback, KLighDExtension } from "./klighd-extension";
 import { LspHandler } from "./lsp-handler";
 import { StorageService } from "./storage/storage-service";
 import { ReportChangeMessage } from "./storage/messages";
-import { Action, isAction } from "sprotty-vscode-protocol";
+import { Action, isAction } from "sprotty-protocol";
 
 // potential exports for other extensions to improve their dev experience
 // Currently, this only includes our command string. Requires this extension to be published as a package.
@@ -139,7 +139,7 @@ export function activate(context: vscode.ExtensionContext): void {
     );
 }
 
-function isLanguageClient(client: unknown): client is LanguageClient {
+function isLanguageClient(client: unknown): client is CommonLanguageClient {
     // Instanceof checks do not work, since the LanguageClient class from the
     // host extension is not the same as this LanguageClient class.
     // Both classes are part of different bundles and thus module system.

--- a/applications/klighd-vscode/src/klighd-extension.ts
+++ b/applications/klighd-vscode/src/klighd-extension.ts
@@ -19,19 +19,20 @@ import {
     RefreshDiagramAction,
     RefreshLayoutAction,
 } from "@kieler/klighd-core";
-import { CenterAction, RequestExportSvgAction } from "sprotty";
-import { Action, serializeUri, SprottyWebview } from "sprotty-vscode";
+import { RequestExportSvgAction } from "sprotty";
+import { Action, CenterAction } from "sprotty-protocol";
+import { serializeUri, SprottyWebview } from "sprotty-vscode";
 import { ActionHandler } from "sprotty-vscode/lib/action-handler";
 import { SprottyDiagramIdentifier, SprottyLspVscodeExtension } from "sprotty-vscode/lib/lsp";
 import { commands, ExtensionContext, Uri } from "vscode";
-import { LanguageClient } from "vscode-languageclient";
+import { CommonLanguageClient } from "vscode-languageclient";
 import { command, diagramType, extensionId } from "./constants";
 import { StorageService } from "./storage/storage-service";
 import { KLighDWebview } from "./klighd-webview";
 
 /** Options required to construct a KLighDExtension */
 interface KLighDExtensionOptions {
-    lsClient: LanguageClient;
+    lsClient: CommonLanguageClient;
     supportedFileEnding: string[];
     storageService: StorageService;
 }
@@ -67,7 +68,7 @@ export class KLighDExtension extends SprottyLspVscodeExtension {
     // before modifications to the instance. The only possible hack around this
     // problem is a static property.
     // PS. This hack is approved by "als".
-    private static lsClient: LanguageClient;
+    private static lsClient: CommonLanguageClient;
     private supportedFileEndings: string[];
 
     // This service is required here, so it can be hooked into created webviews.
@@ -163,7 +164,7 @@ export class KLighDExtension extends SprottyLspVscodeExtension {
         return this.supportedFileEndings.some((ending) => path.endsWith(ending));
     }
 
-    protected override activateLanguageClient(): LanguageClient {
+    protected override activateLanguageClient(): CommonLanguageClient {
         // This extension does not manage any language clients. It receives it's
         // clients from a host extension. See the "setLanguageClient" command.
         return KLighDExtension.lsClient;
@@ -202,7 +203,7 @@ export class KLighDExtension extends SprottyLspVscodeExtension {
             commands.registerCommand(command.diagramCenter, () => {
                 const activeWebview = this.findActiveWebview();
                 if (activeWebview) {
-                    activeWebview.dispatch(new CenterAction([], true));
+                    activeWebview.dispatch(CenterAction.create([], { animate: true }));
                 }
             })
         );
@@ -210,7 +211,7 @@ export class KLighDExtension extends SprottyLspVscodeExtension {
             commands.registerCommand(command.diagramFit, () => {
                 const activeWebview = this.findActiveWebview();
                 if (activeWebview) {
-                    activeWebview.dispatch(new KlighdFitToScreenAction(true));
+                    activeWebview.dispatch(KlighdFitToScreenAction.create(true));
                 }
             })
         );
@@ -218,7 +219,7 @@ export class KLighDExtension extends SprottyLspVscodeExtension {
             commands.registerCommand(command.diagramLayout, () => {
                 const activeWebview = this.findActiveWebview();
                 if (activeWebview) {
-                    activeWebview.dispatch(new RefreshLayoutAction());
+                    activeWebview.dispatch(RefreshLayoutAction.create());
                 }
             })
         );
@@ -226,7 +227,7 @@ export class KLighDExtension extends SprottyLspVscodeExtension {
             commands.registerCommand(command.diagramRefresh, () => {
                 const activeWebview = this.findActiveWebview();
                 if (activeWebview) {
-                    activeWebview.dispatch(new RefreshDiagramAction());
+                    activeWebview.dispatch(RefreshDiagramAction.create());
                 }
             })
         );
@@ -234,7 +235,7 @@ export class KLighDExtension extends SprottyLspVscodeExtension {
             commands.registerCommand(command.diagramExport, () => {
                 const activeWebview = this.findActiveWebview();
                 if (activeWebview) {
-                    activeWebview.dispatch(new RequestExportSvgAction());
+                    activeWebview.dispatch(RequestExportSvgAction.create());
                 }
             })
         );

--- a/applications/klighd-vscode/src/klighd-webview.ts
+++ b/applications/klighd-vscode/src/klighd-webview.ts
@@ -87,7 +87,7 @@ export class KLighDWebview extends SprottyLspWebview {
     private sendConfiguration() {
         const config = workspace.getConfiguration(extensionId);
         this.dispatch(
-            new SetPreferencesAction({
+            SetPreferencesAction.create({
                 resizeToFit: config.get<boolean>("initialResizeToFit"),
                 forceLightBackground: config.get<boolean>("useLightBackground"),
                 shouldSelectDiagram: config.get<boolean>("initialShouldSelectDiagram"),

--- a/applications/klighd-vscode/src/lsp-handler.ts
+++ b/applications/klighd-vscode/src/lsp-handler.ts
@@ -15,13 +15,13 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 import { window, TextEdit, workspace, Uri, WorkspaceEdit } from "vscode";
-import { LanguageClient, Range as LspRange } from "vscode-languageclient";
+import { CommonLanguageClient, Range as LspRange } from "vscode-languageclient";
 
 /** Handles KLighD specific LSP extensions. */
 export class LspHandler {
     private lastEditSuccessful: boolean;
 
-    constructor(private lsClient: LanguageClient) {
+    constructor(private lsClient: CommonLanguageClient) {
         lsClient.onReady().then(() => {
             lsClient.onNotification("general/sendMessage", this.handleGeneralMessage.bind(this));
             lsClient.onNotification(

--- a/applications/klighd-vscode/src/storage/storage-service.ts
+++ b/applications/klighd-vscode/src/storage/storage-service.ts
@@ -16,7 +16,7 @@
  */
 
 import { Memento } from "vscode";
-import { LanguageClient } from "vscode-languageclient";
+import { CommonLanguageClient } from "vscode-languageclient";
 import { KLighDWebview } from "../klighd-webview";
 import { PersistenceMessage } from "./messages";
 
@@ -31,7 +31,7 @@ export class StorageService {
     private static readonly key = "klighdPersistence";
     private memento: Memento;
 
-    constructor(memento: Memento, client: LanguageClient) {
+    constructor(memento: Memento, client: CommonLanguageClient) {
         this.memento = memento;
 
         const data = this.getData();

--- a/applications/klighd-vscode/webpack.config.js
+++ b/applications/klighd-vscode/webpack.config.js
@@ -48,6 +48,20 @@ const extensionConfig = {
                     },
                 ],
             },
+            {
+                test: /\.css$/,
+                use: ["css-loader"],
+            },
+            {
+                test: /\.(ttf)$/,
+                loader: 'file-loader',
+                options: {
+                    name: '[name].[ext]',
+                    outputPath: '',
+                    publicPath: '..',
+                    postTransformPublicPath: (p) => `__webpack_public_path__ + ${p}`,
+                }
+            },
         ],
     },
     plugins: [new webpack.WatchIgnorePlugin([/\.d\.ts$/])],
@@ -89,6 +103,16 @@ const webviewConfig = {
             {
                 test: /\.css$/,
                 use: ["style-loader", "css-loader"],
+            },
+            {
+                test: /\.(ttf)$/,
+                loader: 'file-loader',
+                options: {
+                    name: '[name].[ext]',
+                    outputPath: '',
+                    publicPath: '..',
+                    postTransformPublicPath: (p) => `__webpack_public_path__ + ${p}`,
+                }
             },
         ],
     },

--- a/packages/klighd-core/examples/counter-panel.tsx
+++ b/packages/klighd-core/examples/counter-panel.tsx
@@ -18,6 +18,7 @@
 /** @jsx html */
 import { VNode } from "snabbdom";
 import { html } from "sprotty"; // eslint-disable-line @typescript-eslint/no-unused-vars
+import { FeatherIcon } from "../src/feather-icons-snabbdom/feather-icons-snabbdom";
 import { SidebarPanel } from "../src/sidebar/sidebar-panel";
 
 /**
@@ -64,6 +65,6 @@ export class CounterPanel extends SidebarPanel {
     }
 
     get icon(): VNode {
-        return <i attrs={{ "data-feather": "percent" }}></i>;
+        return <FeatherIcon iconId={"percent"}/>;
     }
 }

--- a/packages/klighd-core/examples/counter-panel.tsx
+++ b/packages/klighd-core/examples/counter-panel.tsx
@@ -16,8 +16,8 @@
  */
 
 /** @jsx html */
-import { html } from "snabbdom-jsx"; // eslint-disable-line @typescript-eslint/no-unused-vars
-import { VNode } from "snabbdom/vnode";
+import { VNode } from "snabbdom";
+import { html } from "sprotty"; // eslint-disable-line @typescript-eslint/no-unused-vars
 import { SidebarPanel } from "../src/sidebar/sidebar-panel";
 
 /**

--- a/packages/klighd-core/package.json
+++ b/packages/klighd-core/package.json
@@ -26,7 +26,7 @@
         "@kieler/klighd-interactive": "^0.2.1",
         "feather-icons": "^4.28.0",
         "inversify": "^5.0.1",
-        "sprotty": "0.10.0"
+        "sprotty": "0.11.1"
     },
     "devDependencies": {
         "@types/feather-icons": "^4.7.0",

--- a/packages/klighd-core/package.json
+++ b/packages/klighd-core/package.json
@@ -25,8 +25,8 @@
     "dependencies": {
         "@kieler/klighd-interactive": "^0.2.1",
         "feather-icons": "^4.28.0",
-        "inversify": "5.0.1",
-        "sprotty": "0.9.0"
+        "inversify": "^5.0.1",
+        "sprotty": "0.10.0"
     },
     "devDependencies": {
         "@types/feather-icons": "^4.7.0",

--- a/packages/klighd-core/src/actions/action-listener.ts
+++ b/packages/klighd-core/src/actions/action-listener.ts
@@ -3,7 +3,7 @@
  *
  * http://rtsys.informatik.uni-kiel.de/kieler
  *
- * Copyright 2018-2019 by
+ * Copyright 2018-2021 by
  * + Kiel University
  *   + Department of Computer Science
  *     + Real-Time and Embedded Systems Group
@@ -14,7 +14,8 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import { Action, MouseListener, SModelElement } from 'sprotty';
+import { MouseListener, SModelElement } from 'sprotty';
+import { Action } from "sprotty-protocol";
 import { KAction, ModifierState, SKGraphElement, Trigger } from '../skgraph-models';
 import { findRendering, getSemanticElement } from '../skgraph-utils';
 import { PerformActionAction } from './actions';
@@ -78,7 +79,7 @@ export class ActionListener extends MouseListener {
                 && this.modifierStateMatches(action.ctrlCmdPressed, event.ctrlKey)
                 && this.modifierStateMatches(action.shiftPressed, event.shiftKey)
                 && this.eventsMatch(event, eventType, action.trigger)) {
-                actions.push(new PerformActionAction(action.actionId, target.id, semanticElementId, target.root.revision))
+                actions.push(PerformActionAction.create(action.actionId, target.id, semanticElementId, target.root.revision))
             }
         })
         return actions

--- a/packages/klighd-core/src/actions/action-listener.ts
+++ b/packages/klighd-core/src/actions/action-listener.ts
@@ -14,7 +14,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import { Action, MouseListener, SModelElement } from 'sprotty/lib';
+import { Action, MouseListener, SModelElement } from 'sprotty';
 import { KAction, ModifierState, SKGraphElement, Trigger } from '../skgraph-models';
 import { findRendering, getSemanticElement } from '../skgraph-utils';
 import { PerformActionAction } from './actions';

--- a/packages/klighd-core/src/actions/actions-module.ts
+++ b/packages/klighd-core/src/actions/actions-module.ts
@@ -15,7 +15,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 import { ContainerModule } from 'inversify';
-import { TYPES } from 'sprotty/lib';
+import { TYPES } from 'sprotty';
 import { ActionListener } from './action-listener';
 
 /**

--- a/packages/klighd-core/src/actions/actions.ts
+++ b/packages/klighd-core/src/actions/actions.ts
@@ -16,7 +16,7 @@
  */
 import {
     Action, RequestAction, ResponseAction, SModelRootSchema, Match, UpdateModelAction, FitToScreenAction
-} from 'sprotty/lib';
+} from 'sprotty';
 import { KImage } from '../skgraph-models';
 
 /**

--- a/packages/klighd-core/src/base/external-helpers.ts
+++ b/packages/klighd-core/src/base/external-helpers.ts
@@ -16,7 +16,8 @@
  */
 
 import { Container } from "inversify";
-import { IActionDispatcher, RequestModelAction, TYPES, Viewport } from "sprotty";
+import { IActionDispatcher, TYPES } from "sprotty";
+import { RequestModelAction, Viewport } from "sprotty-protocol";
 
 // This module contains helper methods that can simplify the interaction with the Sprotty container from outside this package.
 // The main goal of each helper is to abstract Sprotty internal implementations.
@@ -34,7 +35,7 @@ export async function requestModel(
     actionDispatcher: IActionDispatcher,
     sourceUri: string
 ): Promise<void> {
-    await actionDispatcher.dispatch(new RequestModelAction({ sourceUri, diagramType }));
+    await actionDispatcher.dispatch(RequestModelAction.create({ sourceUri, diagramType }));
 }
 
 export function getBookmarkViewport(x: number, y: number, zoom: number): Viewport | null {

--- a/packages/klighd-core/src/base/registry.ts
+++ b/packages/klighd-core/src/base/registry.ts
@@ -16,7 +16,8 @@
  */
 
 import { injectable } from "inversify";
-import { Action, IActionHandler, ICommand } from "sprotty";
+import { IActionHandler, ICommand } from "sprotty";
+import { Action } from "sprotty-protocol";
 
 type Handler = () => void;
 

--- a/packages/klighd-core/src/bookmarks/bookmark-module.ts
+++ b/packages/klighd-core/src/bookmarks/bookmark-module.ts
@@ -18,7 +18,7 @@
 import { ContainerModule } from "inversify";
 import { configureActionHandler, configureCommand } from "sprotty";
 import { DISymbol } from "../di.symbols";
-import { AddBookmarkAction, CreateBookmarkAction, CreateBookmarkCommand, DeleteBookmarkAction, GoToBookmarkAction, RenameBookmarkAction, SetInitialBookmark } from "./bookmark"
+import { AddBookmarkAction, CreateBookmarkAction, CreateBookmarkCommand, DeleteBookmarkAction, GoToBookmarkAction, RenameBookmarkAction, SetInitialBookmarkAction } from "./bookmark"
 import { BookmarkPanel } from "./bookmark-panel";
 import { BookmarkRegistry } from "./bookmark-registry";
 
@@ -41,7 +41,7 @@ const bookmarkModule = new ContainerModule((bind, unbind, isBound, rebind) => {
     configureActionHandler(context, DeleteBookmarkAction.KIND, DISymbol.BookmarkRegistry);
     configureActionHandler(context, RenameBookmarkAction.KIND, DISymbol.BookmarkRegistry);
     configureActionHandler(context, GoToBookmarkAction.KIND, DISymbol.BookmarkRegistry);
-    configureActionHandler(context, SetInitialBookmark.KIND, DISymbol.BookmarkRegistry);
+    configureActionHandler(context, SetInitialBookmarkAction.KIND, DISymbol.BookmarkRegistry);
 
 });
 

--- a/packages/klighd-core/src/bookmarks/bookmark-panel.tsx
+++ b/packages/klighd-core/src/bookmarks/bookmark-panel.tsx
@@ -20,6 +20,7 @@ import { inject, injectable, postConstruct } from "inversify";
 import { VNode } from "snabbdom";
 import { html, IActionDispatcher, TYPES } from "sprotty"; // eslint-disable-line @typescript-eslint/no-unused-vars
 import { DISymbol } from "../di.symbols";
+import { FeatherIcon } from '../feather-icons-snabbdom/feather-icons-snabbdom';
 import { SidebarPanel } from "../sidebar";
 import { BookmarkRegistry } from "./bookmark-registry";
 import { Bookmark, GoToBookmarkAction, CreateBookmarkAction, DeleteBookmarkAction, AddBookmarkAction, RenameBookmarkAction } from "./bookmark";
@@ -46,7 +47,7 @@ export class BookmarkPanel extends SidebarPanel {
         return "Bookmarks"
     }
     get icon(): VNode {
-        return <i attrs={{ "data-feather": "bookmark" }}></i>
+        return <FeatherIcon iconId={"bookmark"}/>
     }
     render(): VNode {
         return <div>
@@ -56,14 +57,14 @@ export class BookmarkPanel extends SidebarPanel {
                     class-options__icon-button="true"
                     on-click={() => this.newBookmark()}
                 >
-                    <i attrs={{ "data-feather": "bookmark" }} />
+                    <FeatherIcon iconId={"bookmark"}/>
                 </button>
                 <button
                     title="Load from Clipboard"
                     class-options__icon-button="true"
                     on-click={() => this.handleBookmarkPast()}
                 >
-                    <i attrs={{ "data-feather": "upload" }} />
+                    <FeatherIcon iconId={"upload"}/>
                 </button>
             </div>
             {this.renderBookmarkList()}
@@ -89,21 +90,21 @@ export class BookmarkPanel extends SidebarPanel {
                     class-options__icon-button="true"
                     on-click={() => this.handleBookmarkGoto(bookmark)}
                 >
-                    <i attrs={{ "data-feather": "map-pin" }} />
+                    <FeatherIcon iconId={"map-pin"}/>
                 </button>
                 <button
                     title="Save to Clipboard"
                     class-options__icon-button="true"
                     on-click={() => this.handleBookmarkCopy(bookmark)}
                 >
-                    <i attrs={{ "data-feather": "download" }} />
+                    <FeatherIcon iconId={"download"}/>
                 </button>
                 <button
                     title="Delete Bookmark"
                     class-options__icon-button="true"
                     on-click={() => this.deleteBookmark(bookmark)}
                 >
-                    <i attrs={{ "data-feather": "trash-2" }} />
+                    <FeatherIcon iconId={"trash-2"}/>
                 </button>
                 <button
                     id={bookmark.editId}
@@ -111,7 +112,7 @@ export class BookmarkPanel extends SidebarPanel {
                     class-options__icon-button="true"
                     on-click={() => this.startBookmarkNameEdit(bookmark)}
                 >
-                    <i attrs={{ "data-feather": "edit-3" }} />
+                    <FeatherIcon iconId={"edit-3"}/>
                 </button>
                 <span id={bookmark.saveId} class-options__hidden="true">
                     <button
@@ -119,7 +120,7 @@ export class BookmarkPanel extends SidebarPanel {
                         class-options__icon-button="true"
                         on-click={() => this.saveBookmarkName(bookmark)}
                     >
-                        <i attrs={{ "data-feather": "check" }} />
+                        <FeatherIcon iconId={"check"}/>
                     </button>
                     <input type="text" value={bookmark.name ?? ""} placeholder="Enter Bookmark Name" on-keypress={(event: KeyboardEvent) => this.inputSaveBookmarkName(bookmark, event)} />
                 </span>
@@ -128,16 +129,16 @@ export class BookmarkPanel extends SidebarPanel {
     }
 
     protected handleBookmarkGoto(bookmark: Bookmark): void {
-        this.actionDispatcher.dispatch(new GoToBookmarkAction(bookmark));
+        this.actionDispatcher.dispatch(GoToBookmarkAction.create(bookmark));
     }
 
     protected newBookmark(): void {
-        this.actionDispatcher.dispatch(new CreateBookmarkAction());
+        this.actionDispatcher.dispatch(CreateBookmarkAction.create());
     }
 
     protected deleteBookmark(bookmark: Bookmark): void {
         if (bookmark.bookmarkIndex !== undefined) {
-            this.actionDispatcher.dispatch(new DeleteBookmarkAction(bookmark.bookmarkIndex))
+            this.actionDispatcher.dispatch(DeleteBookmarkAction.create(bookmark.bookmarkIndex))
         }
     }
 
@@ -146,7 +147,7 @@ export class BookmarkPanel extends SidebarPanel {
 
         if (Bookmark.isBookmark(bookmark)) {
             bookmark.clone = Bookmark.prototype.clone
-            this.actionDispatcher.dispatch(new AddBookmarkAction(bookmark.clone()))
+            this.actionDispatcher.dispatch(AddBookmarkAction.create(bookmark.clone()))
         } else {
             console.log("Clipboard does not contain a valid Bookmark")
         }
@@ -172,7 +173,7 @@ export class BookmarkPanel extends SidebarPanel {
         if (save && bookmark.bookmarkIndex !== undefined) {
             save.classList.toggle("options__hidden", true)
             const new_name = save.getElementsByTagName("input")[0].value ?? undefined;
-            this.actionDispatcher.dispatch(new RenameBookmarkAction(bookmark.bookmarkIndex, new_name));
+            this.actionDispatcher.dispatch(RenameBookmarkAction.create(bookmark.bookmarkIndex, new_name));
         }
     }
 

--- a/packages/klighd-core/src/bookmarks/bookmark-panel.tsx
+++ b/packages/klighd-core/src/bookmarks/bookmark-panel.tsx
@@ -17,9 +17,8 @@
  */
 
 import { inject, injectable, postConstruct } from "inversify";
-import { VNode } from "snabbdom/vnode";
-import { html } from "snabbdom-jsx"; // eslint-disable-line @typescript-eslint/no-unused-vars
-import { IActionDispatcher, TYPES } from "sprotty";
+import { VNode } from "snabbdom";
+import { html, IActionDispatcher, TYPES } from "sprotty"; // eslint-disable-line @typescript-eslint/no-unused-vars
 import { DISymbol } from "../di.symbols";
 import { SidebarPanel } from "../sidebar";
 import { BookmarkRegistry } from "./bookmark-registry";

--- a/packages/klighd-core/src/bookmarks/bookmark-panel.tsx
+++ b/packages/klighd-core/src/bookmarks/bookmark-panel.tsx
@@ -53,14 +53,14 @@ export class BookmarkPanel extends SidebarPanel {
             <div>
                 <button
                     title="Create new Bookmark"
-                    classNames="options__icon-button"
+                    class-options__icon-button="true"
                     on-click={() => this.newBookmark()}
                 >
                     <i attrs={{ "data-feather": "bookmark" }} />
                 </button>
                 <button
                     title="Load from Clipboard"
-                    classNames="options__icon-button"
+                    class-options__icon-button="true"
                     on-click={() => this.handleBookmarkPast()}
                 >
                     <i attrs={{ "data-feather": "upload" }} />
@@ -86,21 +86,21 @@ export class BookmarkPanel extends SidebarPanel {
                 <legend>{bookmark.name ?? ("Bookmark " + bookmark.bookmarkIndex)}</legend>
                 <button
                     title="Goto"
-                    classNames="options__icon-button"
+                    class-options__icon-button="true"
                     on-click={() => this.handleBookmarkGoto(bookmark)}
                 >
                     <i attrs={{ "data-feather": "map-pin" }} />
                 </button>
                 <button
                     title="Save to Clipboard"
-                    classNames="options__icon-button"
+                    class-options__icon-button="true"
                     on-click={() => this.handleBookmarkCopy(bookmark)}
                 >
                     <i attrs={{ "data-feather": "download" }} />
                 </button>
                 <button
                     title="Delete Bookmark"
-                    classNames="options__icon-button"
+                    class-options__icon-button="true"
                     on-click={() => this.deleteBookmark(bookmark)}
                 >
                     <i attrs={{ "data-feather": "trash-2" }} />
@@ -108,15 +108,15 @@ export class BookmarkPanel extends SidebarPanel {
                 <button
                     id={bookmark.editId}
                     title="Edit Bookmark Name"
-                    classNames="options__icon-button"
+                    class-options__icon-button="true"
                     on-click={() => this.startBookmarkNameEdit(bookmark)}
                 >
                     <i attrs={{ "data-feather": "edit-3" }} />
                 </button>
-                <span id={bookmark.saveId} classNames="options__hidden">
+                <span id={bookmark.saveId} class-options__hidden="true">
                     <button
                         title="Save Bookmark Name"
-                        classNames="options__icon-button"
+                        class-options__icon-button="true"
                         on-click={() => this.saveBookmarkName(bookmark)}
                     >
                         <i attrs={{ "data-feather": "check" }} />

--- a/packages/klighd-core/src/bookmarks/bookmark-registry.ts
+++ b/packages/klighd-core/src/bookmarks/bookmark-registry.ts
@@ -16,11 +16,12 @@
  */
 
 import { injectable, inject } from "inversify";
-import { Action, ICommand } from "sprotty";
+import { ICommand } from "sprotty";
+import { Action } from "sprotty-protocol";
 import { Registry } from "../base/registry";
 import { DISymbol } from "../di.symbols";
 import { PreferencesRegistry } from "../preferences-registry";
-import { AddBookmarkAction, Bookmark, DeleteBookmarkAction, GoToBookmarkAction, GoToBookmarkCommand, RenameBookmarkAction, SetInitialBookmark } from "./bookmark";
+import { AddBookmarkAction, Bookmark, DeleteBookmarkAction, GoToBookmarkAction, GoToBookmarkCommand, RenameBookmarkAction, SetInitialBookmarkAction } from "./bookmark";
 
 /**
  * A simple {@link Registry} that holds a list of all added Bookmarks
@@ -42,7 +43,7 @@ export class BookmarkRegistry extends Registry {
 
             return new GoToBookmarkCommand(action, this.preferenceRegistry.preferences.animateGoToBookmark)
 
-        } else if (SetInitialBookmark.isThisAction(action)) {
+        } else if (SetInitialBookmarkAction.isThisAction(action)) {
 
             this._initialBookmark = action.bookmark
             this.addBookmark(this._initialBookmark)

--- a/packages/klighd-core/src/bookmarks/bookmark.ts
+++ b/packages/klighd-core/src/bookmarks/bookmark.ts
@@ -16,8 +16,8 @@
  */
 
 import { inject, injectable } from "inversify";
-import { ActionDispatcher, Command, CommandExecutionContext, CommandReturn, isViewport, SetViewportAction, SetViewportCommand, TYPES, Viewport } from "sprotty";
-import { Action } from "sprotty";
+import { ActionDispatcher, Command, CommandExecutionContext, CommandReturn, isViewport, SetViewportCommand, TYPES } from "sprotty";
+import { Action, SetViewportAction, Viewport } from "sprotty-protocol";
 
 /**
  * A Bookmark
@@ -75,12 +75,21 @@ export class Bookmark {
 /**
  * An action to create a new Bookmark at the current Viewport
  */
-export class CreateBookmarkAction implements Action {
-    static readonly KIND = 'create-bookmark';
-    readonly kind = CreateBookmarkAction.KIND;
+export interface CreateBookmarkAction extends Action {
+    kind: typeof CreateBookmarkAction.KIND
+}
+
+export namespace CreateBookmarkAction {
+    export const KIND = 'create-bookmark'
+
+    export function create(): CreateBookmarkAction {
+        return {
+            kind: KIND,
+        }
+    }
 
     /** Type predicate to narrow an action to this action. */
-    static isThisAction(action: Action): action is CreateBookmarkAction {
+    export function isThisAction(action: Action): action is CreateBookmarkAction {
         return action.kind === CreateBookmarkAction.KIND;
     }
 }
@@ -110,21 +119,21 @@ export class CreateBookmarkCommand extends Command {
         if (isViewport(model)) {
             // copy the viewport as we do want the Bookmark to stay where we are now
             this.bookmark = new Bookmark({ scroll: model.scroll, zoom: model.zoom });
-            this.actionDispatcher.dispatch(new AddBookmarkAction(this.bookmark))
+            this.actionDispatcher.dispatch(AddBookmarkAction.create(this.bookmark))
         }
         return model;
     }
 
     undo(context: CommandExecutionContext): CommandReturn {
         if (this.bookmark?.bookmarkIndex) {
-            this.actionDispatcher.dispatch(new DeleteBookmarkAction(this.bookmark.bookmarkIndex))
+            this.actionDispatcher.dispatch(DeleteBookmarkAction.create(this.bookmark.bookmarkIndex))
         }
         return context.root;
     }
 
     redo(context: CommandExecutionContext): CommandReturn {
         if (this.bookmark) {
-            this.actionDispatcher.dispatch(new AddBookmarkAction(this.bookmark))
+            this.actionDispatcher.dispatch(AddBookmarkAction.create(this.bookmark))
         }
         return context.root;
     }
@@ -133,14 +142,23 @@ export class CreateBookmarkCommand extends Command {
 /**
  * An action to add a Bookmark to the BookmarkRegistry
  */
-export class AddBookmarkAction implements Action {
-    static readonly KIND = 'add-bookmark';
-    readonly kind = AddBookmarkAction.KIND;
+export interface AddBookmarkAction extends Action {
+    kind: typeof AddBookmarkAction.KIND
+    bookmark: Bookmark
+}
 
-    constructor(public bookmark: Bookmark) { }
+export namespace AddBookmarkAction {
+    export const KIND = 'add-bookmark'
+
+    export function create(bookmark: Bookmark): AddBookmarkAction {
+        return {
+            kind: KIND,
+            bookmark,
+        }
+    }
 
     /** Type predicate to narrow an action to this action. */
-    static isThisAction(action: Action): action is AddBookmarkAction {
+    export function isThisAction(action: Action): action is AddBookmarkAction {
         return action.kind === AddBookmarkAction.KIND;
     }
 }
@@ -148,26 +166,46 @@ export class AddBookmarkAction implements Action {
 /**
  * An action to delete a Bookmark from the BookmarkRegistry
  */
-export class DeleteBookmarkAction implements Action {
-    static readonly KIND = 'delete-bookmark';
-    readonly kind = DeleteBookmarkAction.KIND;
+export interface DeleteBookmarkAction extends Action {
+    kind: typeof DeleteBookmarkAction.KIND
+    bookmark_index: number
+}
 
-    constructor(public bookmark_index: number) { }
+export namespace DeleteBookmarkAction {
+    export const KIND = 'delete-bookmark'
+
+    export function create(bookmark_index: number): DeleteBookmarkAction {
+        return {
+            kind: KIND,
+            bookmark_index,
+        }
+    }
 
     /** Type predicate to narrow an action to this action. */
-    static isThisAction(action: Action): action is DeleteBookmarkAction {
+    export function isThisAction(action: Action): action is DeleteBookmarkAction {
         return action.kind === DeleteBookmarkAction.KIND;
     }
 }
 
-export class RenameBookmarkAction implements Action {
-    static readonly KIND = 'rename-bookmark';
-    readonly kind = RenameBookmarkAction.KIND;
+export interface RenameBookmarkAction extends Action {
+    kind: typeof RenameBookmarkAction.KIND
+    bookmark_index: number
+    new_name: string
+}
 
-    constructor(public bookmark_index: number, public new_name: string) { }
+export namespace RenameBookmarkAction {
+    export const KIND = 'rename-bookmark'
+
+    export function create(bookmark_index: number, new_name: string): RenameBookmarkAction {
+        return {
+            kind: KIND,
+            bookmark_index,
+            new_name,
+        }
+    }
 
     /** Type predicate to narrow an action to this action. */
-    static isThisAction(action: Action): action is RenameBookmarkAction {
+    export function isThisAction(action: Action): action is RenameBookmarkAction {
         return action.kind === RenameBookmarkAction.KIND;
     }
 }
@@ -175,18 +213,23 @@ export class RenameBookmarkAction implements Action {
 /**
  * An action to return to a bookmarked Viewport
  */
-export class GoToBookmarkAction implements Action {
-    static readonly KIND = 'get-bookmark';
-    readonly kind = GoToBookmarkAction.KIND;
+export interface GoToBookmarkAction extends Action {
+    kind: typeof GoToBookmarkAction.KIND
+    bookmark: Bookmark
+}
 
-    readonly bookmark: Bookmark;
+export namespace GoToBookmarkAction {
+    export const KIND = 'get-bookmark'
 
-    constructor(bookmark: Bookmark) {
-        this.bookmark = bookmark.clone();
+    export function create(bookmark: Bookmark): GoToBookmarkAction {
+        return {
+            kind: KIND,
+            bookmark,
+        }
     }
 
     /** Type predicate to narrow an action to this action. */
-    static isThisAction(action: Action): action is GoToBookmarkAction {
+    export function isThisAction(action: Action): action is GoToBookmarkAction {
         return action.kind === GoToBookmarkAction.KIND;
     }
 }
@@ -204,7 +247,7 @@ export class GoToBookmarkCommand implements Command {
     }
 
     execute(context: CommandExecutionContext): CommandReturn {
-        const viewAction = new SetViewportAction(context.root.id, this.action.bookmark.place, this.animate)
+        const viewAction = SetViewportAction.create(context.root.id, this.action.bookmark.place, { animate: this.animate })
         this.setCommand = new SetViewportCommand(viewAction)
 
         return this.setCommand.execute(context)
@@ -218,18 +261,23 @@ export class GoToBookmarkCommand implements Command {
 
 }
 
-export class SetInitialBookmark implements Action {
-    static readonly KIND = 'init-bookmark';
-    readonly kind = SetInitialBookmark.KIND;
+export interface SetInitialBookmarkAction extends Action {
+    kind: typeof SetInitialBookmarkAction.KIND
+    bookmark: Bookmark
+}
 
-    readonly bookmark: Bookmark;
+export namespace SetInitialBookmarkAction {
+    export const KIND = 'init-bookmark'
 
-    constructor(bookmark: Bookmark) {
-        this.bookmark = bookmark
+    export function create(bookmark: Bookmark): SetInitialBookmarkAction {
+        return {
+            kind: KIND,
+            bookmark,
+        }
     }
 
     /** Type predicate to narrow an action to this action. */
-    static isThisAction(action: Action): action is SetInitialBookmark {
-        return action.kind === SetInitialBookmark.KIND;
+    export function isThisAction(action: Action): action is SetInitialBookmarkAction {
+        return action.kind === SetInitialBookmarkAction.KIND;
     }
 }

--- a/packages/klighd-core/src/bookmarks/bookmark.ts
+++ b/packages/klighd-core/src/bookmarks/bookmark.ts
@@ -17,7 +17,7 @@
 
 import { inject, injectable } from "inversify";
 import { ActionDispatcher, Command, CommandExecutionContext, CommandReturn, isViewport, SetViewportAction, SetViewportCommand, TYPES, Viewport } from "sprotty";
-import { Action } from "sprotty/lib/base/actions/action";
+import { Action } from "sprotty";
 
 /**
  * A Bookmark

--- a/packages/klighd-core/src/depth-map.ts
+++ b/packages/klighd-core/src/depth-map.ts
@@ -16,7 +16,8 @@
  */
 
 import { KGraphElement, KNode } from "@kieler/klighd-interactive/lib/constraint-classes";
-import { Point, SChildElement, SModelRoot, Viewport } from "sprotty";
+import { SChildElement, SModelRoot } from "sprotty";
+import { Point, Viewport } from "sprotty-protocol";
 import { RenderOptionsRegistry, FullDetailRelativeThreshold, FullDetailScaleThreshold } from "./options/render-options-registry";
 import { KContainerRendering, K_RECTANGLE } from "./skgraph-models";
 

--- a/packages/klighd-core/src/di.config.ts
+++ b/packages/klighd-core/src/di.config.ts
@@ -21,7 +21,7 @@ import {
     configureModelElement, ConsoleLogger, defaultModule, exportModule, hoverModule, HoverState, HtmlRoot, HtmlRootView, IVNodePostprocessor,
     LogLevel, ModelRendererFactory, modelSourceModule, ModelViewer, overrideViewerOptions, PreRenderedElement, PreRenderedView, RenderingTargetKind, selectModule, SGraph, SGraphFactory,
     TYPES, updateModule, viewportModule, ViewRegistry, configureActionHandler
-} from 'sprotty/lib';
+} from 'sprotty';
 import actionModule from './actions/actions-module';
 import bookmarkModule from './bookmarks/bookmark-module'
 import { DISymbol } from './di.symbols';

--- a/packages/klighd-core/src/diagram-piece-request-manager.ts
+++ b/packages/klighd-core/src/diagram-piece-request-manager.ts
@@ -11,7 +11,8 @@
  * This code is provided under the terms of the Eclipse Public License 2.0 (EPL-2.0).
  */
 
-import { add, Point, SModelElementSchema, ViewportResult } from "sprotty"
+import { ViewportResult } from "sprotty"
+import { Point, SModelElement as SModelElementSchema} from "sprotty-protocol";
 
 /**
  * A IDiagramPieceRequestGenerator manages the ordering of diagram piece
@@ -204,7 +205,7 @@ export class GridDiagramPieceRequestManager implements IDiagramPieceRequestManag
             if (this.idToAbsolutePositions.get(parentId) !== undefined) {
                 // if parent is already known, child position is calculated relative to its parent
                 const parentPos = this.idToAbsolutePositions.get(parentId)!
-                this.idToAbsolutePositions.set(diagramPiece.id, add(parentPos, castPiece.position))
+                this.idToAbsolutePositions.set(diagramPiece.id, Point.add(parentPos, castPiece.position))
             } else {
                 // otherwise the element must be a top level element
                 this.idToAbsolutePositions.set(diagramPiece.id, castPiece.position)
@@ -245,7 +246,7 @@ export class GridDiagramPieceRequestManager implements IDiagramPieceRequestManag
             for (let i = 1; i <= this.maxRingCount; i++) {
                 const ring = this.ringCoords(i)
                 for (let j = 0; j < ring.length; j++) {
-                    const value = this.gridToPieces.get(this.getKey(add(this.currentGridPosition, ring[j])))!
+                    const value = this.gridToPieces.get(this.getKey(Point.add(this.currentGridPosition, ring[j])))!
                     if (value !== undefined && value.length > 0) {
                         piece = value.shift()!
                         return piece

--- a/packages/klighd-core/src/diagram-server.ts
+++ b/packages/klighd-core/src/diagram-server.ts
@@ -31,28 +31,30 @@ import {
 } from "@kieler/klighd-interactive/lib/rect-packing/actions";
 import { inject, injectable } from "inversify";
 import {
-    Action,
     ActionHandlerRegistry,
-    ActionMessage,
     BringToFrontAction,
-    DiagramServer,
-    findElement,
-    generateRequestId,
+    DiagramServerProxy,
     GetViewportAction,
     ICommand,
-    RequestPopupModelAction,
-    SelectAction,
     SetModelCommand,
-    SetPopupModelAction,
     SwitchEditModeAction,
     TYPES,
     ViewportResult,
 } from "sprotty";
 import {
+    Action,
+    ActionMessage,
+    findElement,
+    generateRequestId,
+    RequestPopupModelAction,
+    SelectAction,
+    SetPopupModelAction,
+    UpdateModelAction,
+} from "sprotty-protocol";
+import {
     CheckedImagesAction,
     CheckImagesAction,
     KlighdFitToScreenAction,
-    KlighdUpdateModelAction,
     Pair,
     PerformActionAction,
     RefreshLayoutAction,
@@ -76,7 +78,7 @@ import { UpdateDepthMapModelAction } from "./update/update-depthmap-model";
  * actions and forward them to the server is required.
  */
 @injectable()
-export class KlighdDiagramServer extends DiagramServer {
+export class KlighdDiagramServer extends DiagramServerProxy {
     /** Generic connection to the server used to send and receive actions. */
     private _connection: Connection;
 
@@ -104,9 +106,9 @@ export class KlighdDiagramServer extends DiagramServer {
 
         const wasDiagramModelUpdated =
             message.action.kind === SetModelCommand.KIND ||
-            message.action.kind === KlighdUpdateModelAction.KIND;
+            message.action.kind === UpdateModelAction.KIND;
         if (wasDiagramModelUpdated) {
-            this.actionDispatcher.dispatch(new UpdateDepthMapModelAction());
+            this.actionDispatcher.dispatch(UpdateDepthMapModelAction.create());
 
             if (this.preferencesRegistry.preferences.incrementalDiagramGenerator) {
                 // After model is received request first piece.
@@ -116,12 +118,12 @@ export class KlighdDiagramServer extends DiagramServer {
                 //       with commands
                 // get root diagram piece
                 this.childrenToRequestQueue.reset()
-                this.actionDispatcher.dispatch(new RequestDiagramPieceAction(generateRequestId(), '$root'))
+                this.actionDispatcher.dispatch(RequestDiagramPieceAction.create(generateRequestId(), '$root'))
             }
             if (this.bookmarkRegistry.initialBookmark) {
-                this.actionDispatcher.dispatch(new GoToBookmarkAction(this.bookmarkRegistry.initialBookmark))
+                this.actionDispatcher.dispatch(GoToBookmarkAction.create(this.bookmarkRegistry.initialBookmark))
             } else if (this.preferencesRegistry.preferences.resizeToFit) {
-                this.actionDispatcher.dispatch(new KlighdFitToScreenAction(true));
+                this.actionDispatcher.dispatch(KlighdFitToScreenAction.create(true));
             }
         } else if (message.action.kind === SetDiagramPieceAction.KIND) {
             // add any children of the requested piece as stubs into queue
@@ -174,7 +176,7 @@ export class KlighdDiagramServer extends DiagramServer {
         registry.register(RectPackDeletePositionConstraintAction.KIND, this);
         registry.register(RefreshDiagramAction.KIND, this);
         registry.register(RefreshLayoutAction.KIND, this);
-        registry.register(RequestKlighdPopupModelAction.KIND, this);
+        registry.register(RequestPopupModelAction.KIND, this);
         registry.register(RequestDiagramPieceAction.KIND, this);
         registry.register(SetAspectRatioAction.KIND, this);
         registry.register(SetLayerConstraintAction.KIND, this);
@@ -202,7 +204,7 @@ export class KlighdDiagramServer extends DiagramServer {
         } else if (action.kind === RequestPopupModelAction.KIND) {
             // Handle RequestPopupModelAction if they are modified RequestKlighdPopupModelAction.
             // Other PopupModel requests are simply ignored.
-            if (action instanceof RequestKlighdPopupModelAction)
+            if (RequestKlighdPopupModelAction.isThisAction(action))
                 this.handleRequestKlighdPopupModel(action as RequestKlighdPopupModelAction);
         } else if (action.kind === RequestDiagramPieceAction.KIND) {
             this.handleRequestDiagramPiece(action as RequestDiagramPieceAction)
@@ -225,7 +227,7 @@ export class KlighdDiagramServer extends DiagramServer {
                 notCached.push({ k: image.bundleName, v: image.imagePath });
             }
         }
-        this.actionDispatcher.dispatch(new CheckedImagesAction(notCached));
+        this.actionDispatcher.dispatch(CheckedImagesAction.create(notCached));
     }
 
     handleStoreImages(action: StoreImagesAction): void {
@@ -261,7 +263,7 @@ export class KlighdDiagramServer extends DiagramServer {
             const model = this.popupModelProvider.getPopupModel(action, element);
 
             if (model) {
-                this.actionDispatcher.dispatch(new SetPopupModelAction(model));
+                this.actionDispatcher.dispatch(SetPopupModelAction.create(model));
             }
         }
         return false;
@@ -274,6 +276,6 @@ export class KlighdDiagramServer extends DiagramServer {
     handleViewportResult(action: ViewportResult): void {
         this.childrenToRequestQueue.setViewport(action)
         const child = this.childrenToRequestQueue.dequeue()!
-        this.actionDispatcher.dispatch(new RequestDiagramPieceAction(generateRequestId(), child.id))
+        this.actionDispatcher.dispatch(RequestDiagramPieceAction.create(generateRequestId(), child.id))
     }
 }

--- a/packages/klighd-core/src/feather-icons-snabbdom/feather-icons-snabbdom.tsx
+++ b/packages/klighd-core/src/feather-icons-snabbdom/feather-icons-snabbdom.tsx
@@ -1,0 +1,52 @@
+/*
+ * KIELER - Kiel Integrated Environment for Layout Eclipse RichClient
+ *
+ * http://rtsys.informatik.uni-kiel.de/kieler
+ *
+ * Copyright 2021 by
+ * + Kiel University
+ *   + Department of Computer Science
+ *     + Real-Time and Embedded Systems Group
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+/** @jsx html */
+
+import { icons } from "feather-icons";
+import { VNode } from "snabbdom";
+import { html } from "sprotty"; // eslint-disable-line @typescript-eslint/no-unused-vars
+
+/**
+ * Add the feather icon with the given icon ID to a snabbdom VNode as used in sprotty.
+ * 
+ * @param paramProps properties containing the ID of the feather icon.
+ * @returns The SVG VNode resulting from this feather icon ID.
+ */
+export function FeatherIcon(paramProps: { iconId: string }): VNode {
+  // Something goes wrong with snabbdom functional components as that the props are nested in an
+  // addional props property, which is removed here.
+  const props = (paramProps as any).props as { iconId: string }
+  // Imitates what feather would usually do, all attributes are put in the styles (if possible) and
+  // the classes are written in as well. Missing are the xmlns and viewBox, but they do not seem to
+  // be necessary anyways.
+  const classes: Record<string, boolean> = {"feather": true}
+  classes[`feather-${props.iconId}`] = true
+
+  return <svg 
+    style={{
+      width: '24',
+      height: '24',
+      fill: 'none',
+      stroke: 'currentColor',
+      strokeWidth: '2',
+      strokeLinecap: 'round',
+      strokeLinejoin: 'round'
+    }}
+    class={classes}
+    props={{innerHTML: icons[props.iconId].toString()}}
+  />
+}

--- a/packages/klighd-core/src/hover/popup-provider.ts
+++ b/packages/klighd-core/src/hover/popup-provider.ts
@@ -17,13 +17,15 @@
 
 import { injectable } from "inversify";
 import {
-    HtmlRootSchema,
     IPopupModelProvider,
-    PreRenderedElementSchema,
-    RequestPopupModelAction,
-    SModelElementSchema,
-    SModelRootSchema,
 } from "sprotty";
+import {
+    HtmlRoot as HtmlRootSchema,
+    PreRenderedElement as PreRenderedElementSchema,
+    RequestPopupModelAction,
+    SModelElement as SModelElementSchema,
+    SModelRoot as SModelRootSchema,
+} from "sprotty-protocol";
 import { isSKGraphElement, SKGraphElement } from "../skgraph-models";
 import { findRendering } from "../skgraph-utils";
 import { RequestKlighdPopupModelAction } from "./hover";
@@ -37,7 +39,7 @@ export class PopupModelProvider implements IPopupModelProvider {
     ): SModelRootSchema | undefined {
         if (
             elementSchema &&
-            request instanceof RequestKlighdPopupModelAction &&
+            RequestKlighdPopupModelAction.isThisAction(request) &&
             isSKGraphElement(request.parent) &&
             request.element !== undefined
         ) {

--- a/packages/klighd-core/src/index.ts
+++ b/packages/klighd-core/src/index.ts
@@ -27,6 +27,6 @@ export * from "./options/actions";
 export { ToggleSidebarPanelAction } from "./sidebar/actions";
 export { SetSynthesesAction, SetSynthesisAction } from "./syntheses/actions";
 export { SetPreferencesAction } from "./preferences-registry";
-export { SetInitialBookmark, Bookmark } from "./bookmarks/bookmark"
+export { SetInitialBookmarkAction, Bookmark } from "./bookmarks/bookmark"
 export { RefreshDiagramAction } from "@kieler/klighd-interactive/lib/actions";
-export { ActionMessage } from "sprotty";
+export { ActionMessage } from "sprotty-protocol";

--- a/packages/klighd-core/src/model-viewer.ts
+++ b/packages/klighd-core/src/model-viewer.ts
@@ -60,11 +60,11 @@ export class KlighdModelViewer extends ModelViewer {
         const baseDiv = document.getElementById(this.options.baseDiv);
         if (baseDiv !== null) {
             const newBounds = this.getBoundsInPage(baseDiv as Element);
-            this.actiondispatcher.dispatch(new InitializeCanvasBoundsAction(newBounds));
+            this.actiondispatcher.dispatch(InitializeCanvasBoundsAction.create(newBounds));
 
             // Fit the diagram to the new window size, if the user enabled this behavior
             if (this.preferencesRegistry.preferences.resizeToFit)
-                this.actiondispatcher.dispatch(new KlighdFitToScreenAction(false));
+                this.actiondispatcher.dispatch(KlighdFitToScreenAction.create(false));
         }
     };
 }

--- a/packages/klighd-core/src/options/actions.ts
+++ b/packages/klighd-core/src/options/actions.ts
@@ -15,7 +15,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-import { Action } from "sprotty";
+import { Action } from "sprotty-protocol";
 import {
     DisplayedActionData,
     LayoutOptionUIData,
@@ -25,19 +25,33 @@ import {
 } from "./option-models";
 
 /** Request message from the server to update the diagram options widget on the client. */
-export class UpdateOptionsAction implements Action {
-    static readonly KIND = "updateOptions";
-    readonly kind = UpdateOptionsAction.KIND;
+export interface UpdateOptionsAction extends Action {
+    kind: typeof UpdateOptionsAction.KIND
+    valuedSynthesisOptions: ValuedSynthesisOption[]
+    layoutOptions: LayoutOptionUIData[]
+    actions: DisplayedActionData[]
+    modelUri: string
+}
 
-    constructor(
-        public readonly valuedSynthesisOptions: ValuedSynthesisOption[],
-        public readonly layoutOptions: LayoutOptionUIData[],
-        public readonly actions: DisplayedActionData[],
-        public readonly modelUri: string
-    ) { }
+export namespace UpdateOptionsAction {
+    export const KIND = "updateOptions"
 
-    /** Type predicate to narrow an action to this action. */
-    static isThisAction(action: Action): action is UpdateOptionsAction {
+    export function create(
+        valuedSynthesisOptions: ValuedSynthesisOption[],
+        layoutOptions: LayoutOptionUIData[],
+        actions: DisplayedActionData[],
+        modelUri: string,
+    ): UpdateOptionsAction {
+        return {
+            kind: KIND,
+            valuedSynthesisOptions,
+            layoutOptions, 
+            actions,
+            modelUri,
+        }
+    }
+
+    export function isThisAction(action: Action): action is UpdateOptionsAction {
         return action.kind === UpdateOptionsAction.KIND;
     }
 }
@@ -46,86 +60,144 @@ export class UpdateOptionsAction implements Action {
  * Triggers a action from the options that should be performed.
  * Do not confuse this with PerformActionAction!
  */
-export class PerformOptionsActionAction implements Action {
-    static readonly KIND = "performOptionsAction";
-    readonly kind = PerformOptionsActionAction.KIND;
+export interface PerformOptionsActionAction extends Action {
+    kind: typeof PerformOptionsActionAction.KIND
+    actionId: string
+}
 
-    constructor(readonly actionId: string) { }
+export namespace PerformOptionsActionAction {
+    export const KIND = "performOptionsAction"
 
-    /** Type predicate to narrow an action to this action. */
-    static isThisAction(action: Action): action is PerformOptionsActionAction {
+    export function create(actionId: string): PerformOptionsActionAction {
+        return {
+            kind: KIND,
+            actionId,
+        }
+    }
+
+    export function isThisAction(action: Action): action is PerformOptionsActionAction {
         return action.kind === PerformOptionsActionAction.KIND;
     }
 }
 
 /** Change the value of one or multiple synthesis options. */
-export class SetSynthesisOptionsAction implements Action {
-    static readonly KIND = "setSynthesisOptions";
-    readonly kind = SetSynthesisOptionsAction.KIND;
+export interface SetSynthesisOptionsAction extends Action {
+    kind: typeof SetSynthesisOptionsAction.KIND
+    options: SynthesisOption[]
+}
 
-    constructor(readonly options: SynthesisOption[]) { }
+export namespace SetSynthesisOptionsAction {
+    export const KIND = "setSynthesisOptions"
 
-    /** Type predicate to narrow an action to this action. */
-    static isThisAction(action: Action): action is SetSynthesisOptionsAction {
+    export function create(options: SynthesisOption[]): SetSynthesisOptionsAction {
+        return {
+            kind: KIND,
+            options,
+        }
+    }
+
+    export function isThisAction(action: Action): action is SetSynthesisOptionsAction {
         return action.kind === SetSynthesisOptionsAction.KIND;
     }
 }
 
 /** Resets all synthesis options to default for both server and client. */
-export class ResetSynthesisOptionsAction implements Action {
-    static readonly KIND = "resetSynthesisOptions";
-    readonly kind = ResetSynthesisOptionsAction.KIND;
+export interface ResetSynthesisOptionsAction extends Action {
+    kind: typeof ResetSynthesisOptionsAction.KIND
+}
 
-    /** Type predicate to narrow an action to this action. */
-    static isThisAction(action: Action): action is ResetSynthesisOptionsAction {
+export namespace ResetSynthesisOptionsAction {
+    export const KIND = "resetSynthesisOptions"
+
+    export function create(): ResetSynthesisOptionsAction {
+        return {
+            kind: KIND,
+        }
+    }
+
+    export function isThisAction(action: Action): action is ResetSynthesisOptionsAction {
         return action.kind === ResetSynthesisOptionsAction.KIND;
     }
 }
 
 /** Change the value of one or multiple layout options. */
-export class SetLayoutOptionsAction implements Action {
-    static readonly KIND = "setLayoutOptions";
-    readonly kind = SetLayoutOptionsAction.KIND;
+export interface SetLayoutOptionsAction extends Action {
+    kind: typeof SetLayoutOptionsAction.KIND
+    options: LayoutOptionValue[]
+}
 
-    constructor(readonly options: LayoutOptionValue[]) { }
+export namespace SetLayoutOptionsAction {
+    export const KIND = 'setLayoutOptions'
 
-    /** Type predicate to narrow an action to this action. */
-    static isThisAction(action: Action): action is SetLayoutOptionsAction {
+    export function create(options: LayoutOptionValue[]): SetLayoutOptionsAction {
+        return {
+            kind: KIND,
+            options
+        }
+    }
+
+    export function isThisAction(action: Action): action is SetLayoutOptionsAction {
         return action.kind === SetLayoutOptionsAction.KIND;
     }
 }
 
 /** Resets all layout options to default for both server and client. */
-export class ResetLayoutOptionsAction implements Action {
-    static readonly KIND = "resetLayoutOptions";
-    readonly kind = ResetLayoutOptionsAction.KIND;
+export interface ResetLayoutOptionsAction extends Action {
+    kind: typeof ResetLayoutOptionsAction.KIND
+}
 
-    /** Type predicate to narrow an action to this action. */
-    static isThisAction(action: Action): action is ResetLayoutOptionsAction {
+export namespace ResetLayoutOptionsAction {
+    export const KIND = "resetLayoutOptions"
+
+    export function create(): ResetLayoutOptionsAction {
+        return {
+            kind: KIND,
+        }
+    }
+
+    export function isThisAction(action: Action): action is ResetLayoutOptionsAction {
         return action.kind === ResetLayoutOptionsAction.KIND;
     }
 }
 
 /** Change the value of one or multiple render options. */
-export class SetRenderOptionAction implements Action {
-    static readonly KIND = "setRenderOption";
-    readonly kind = SetRenderOptionAction.KIND;
+export interface SetRenderOptionAction extends Action {
+    kind: typeof SetRenderOptionAction.KIND
+    id: string
+    value: unknown
+}
 
-    constructor(readonly id: string, readonly value: unknown) { }
+export namespace SetRenderOptionAction {
+    export const KIND = "setRenderOption"
 
-    /** Type predicate to narrow an action to this action. */
-    static isThisAction(action: Action): action is SetRenderOptionAction {
+    export function create(id: string, value: unknown): SetRenderOptionAction {
+        return {
+            kind: KIND,
+            id,
+            value
+        }
+    }
+
+    export function isThisAction(action: Action): action is SetRenderOptionAction {
         return action.kind === SetRenderOptionAction.KIND;
     }
 }
 
 /** Resets all render options to default. */
-export class ResetRenderOptionsAction implements Action {
-    static readonly KIND = "resetRenderOptions";
-    readonly kind = ResetRenderOptionsAction.KIND;
+export interface ResetRenderOptionsAction extends Action {
+    kind: typeof ResetRenderOptionsAction.KIND
+}
 
-    /** Type predicate to narrow an action to this action. */
-    static isThisAction(action: Action): action is ResetRenderOptionsAction {
+export namespace ResetRenderOptionsAction {
+    export const KIND = "resetRenderOptions"
+
+    export function create(): ResetRenderOptionsAction {
+        return {
+            kind: KIND,
+        }
+    }
+
+    export function isThisAction(action: Action): action is ResetRenderOptionsAction {
         return action.kind === ResetRenderOptionsAction.KIND;
     }
 }

--- a/packages/klighd-core/src/options/components/option-inputs.tsx
+++ b/packages/klighd-core/src/options/components/option-inputs.tsx
@@ -33,10 +33,12 @@ type CheckOptionProps = BaseProps<boolean>;
 
 /** Render a labeled checkbox input. */
 export function CheckOption(props: CheckOptionProps): VNode {
+    // The sprotty jsx function always puts an additional 'props' key around the element, requiring this hack.
+    props = (props as any as {props: CheckOptionProps}).props
     return (
         <label htmlFor={props.id}>
             <input
-                classNames="options__input"
+                class-options__input="true"
                 type="checkbox"
                 id={props.id}
                 checked={props.value}
@@ -54,13 +56,15 @@ interface ChoiceOptionProps extends BaseProps<string> {
 
 /** Render a labeled group of radio inputs. */
 export function ChoiceOption(props: ChoiceOptionProps): VNode {
+    // The sprotty jsx function always puts an additional 'props' key around the element, requiring this hack.
+    props = (props as any as {props: ChoiceOptionProps}).props
     return (
-        <div classNames="options__input-container">
+        <div class-options__input-container="true">
             <legend>{props.name}</legend>
             {props.availableValues.map((value, i) => (
                 <label key={value} htmlFor={props.availableValuesLabels?.[i] ?? value}>
                     <input
-                        classNames="options__input"
+                        class-options__input="true"
                         type="radio"
                         id={props.availableValuesLabels?.[i] ?? value}
                         checked={props.value === value}
@@ -81,13 +85,15 @@ interface RangeOptionProps extends BaseProps<number> {
 
 /** Render a labeled range slider as input. */
 export function RangeOption(props: RangeOptionProps): VNode {
+    // The sprotty jsx function always puts an additional 'props' key around the element, requiring this hack.
+    props = (props as any as {props: RangeOptionProps}).props
     return (
-        <div classNames="options__column">
+        <div class-options__column="true">
             <label htmlFor={props.id}>
                 {props.name}: {props.value}
             </label>
             <input
-                classNames="options__input"
+                class-options__input="true"
                 type="range"
                 id={props.id}
                 min={props.minValue}
@@ -104,11 +110,13 @@ type TextOptionProps = BaseProps<string>;
 
 /** Renders a labeled text input. */
 export function TextOption(props: TextOptionProps): VNode {
+    // The sprotty jsx function always puts an additional 'props' key around the element, requiring this hack.
+    props = (props as any as {props: TextOptionProps}).props
     return (
-        <div classNames="options__column">
+        <div class-options__column="true">
             <label htmlFor={props.id}>{props.name}</label>
             <input
-                classNames="options__input options__text-field"
+                class-options__input options__text-field="true"
                 type="text"
                 id={props.id}
                 value={props.value}
@@ -120,7 +128,9 @@ export function TextOption(props: TextOptionProps): VNode {
 
 /** Renders a named separator. */
 export function SeparatorOption(props: { name: string; key?: string }): VNode {
-    return <span classNames="options__separator">{props.name}</span>;
+    // The sprotty jsx function always puts an additional 'props' key around the element, requiring this hack.
+    props = (props as any as {props: { name: string; key?: string }}).props
+    return <span class-options__separator="true">{props.name}</span>;
 }
 
 interface CategoryOptionProps extends BaseProps<boolean> {
@@ -130,6 +140,8 @@ interface CategoryOptionProps extends BaseProps<boolean> {
 
 /** Renders a labeled options group. */
 export function CategoryOption(props: CategoryOptionProps, children: VNode[]): VNode {
+    // The sprotty jsx function always puts an additional 'props' key around the element, requiring this hack.
+    props = (props as any as {props: CategoryOptionProps}).props
     function handleToggle(e: any) {
         // The toggle event is also fired if the details are rendered default open.
         // To prevent an infinite toggle loop, change is only called if the state has really changed.
@@ -137,7 +149,7 @@ export function CategoryOption(props: CategoryOptionProps, children: VNode[]): V
     }
 
     return (
-        <details open={props.value} classNames="options__category" on-toggle={handleToggle}>
+        <details open={props.value} class-options__category="true" on-toggle={handleToggle}>
             <summary>{props.name}</summary>
             {children}
         </details>

--- a/packages/klighd-core/src/options/components/option-inputs.tsx
+++ b/packages/klighd-core/src/options/components/option-inputs.tsx
@@ -16,8 +16,8 @@
  */
 
 /** @jsx html */
-import { html } from "snabbdom-jsx"; // eslint-disable-line @typescript-eslint/no-unused-vars
-import { VNode } from "snabbdom/vnode";
+import { VNode } from "snabbdom";
+import { html } from "sprotty"; // eslint-disable-line @typescript-eslint/no-unused-vars
 
 type OptionChangeHandler<T> = (newValue: T) => void;
 

--- a/packages/klighd-core/src/options/components/synthesis-picker.tsx
+++ b/packages/klighd-core/src/options/components/synthesis-picker.tsx
@@ -26,10 +26,12 @@ interface SynthesisPickerProps {
 }
 
 export function SynthesisPicker(props: SynthesisPickerProps): VNode {
+    // The sprotty jsx function always puts an additional 'props' key around the element, requiring this hack.
+    props = (props as any as {props: SynthesisPickerProps}).props
     return (
-        <div classNames="options__column">
+        <div class-options__column="true">
             <label htmlFor="synthesisSelect">Current synthesis:</label>
-            <select id="synthesisSelect" classNames="options__selection" on-change={(e: any) => props.onChange(e.target.value)}>
+            <select id="synthesisSelect" class-options__selection="true" on-change={(e: any) => props.onChange(e.target.value)}>
                 {props.syntheses.map((synthesis) => (
                     <option value={synthesis.id} selected={synthesis.id === props.currentId}>
                         {synthesis.displayName}

--- a/packages/klighd-core/src/options/components/synthesis-picker.tsx
+++ b/packages/klighd-core/src/options/components/synthesis-picker.tsx
@@ -16,8 +16,8 @@
  */
 
 /** @jsx html */
-import { html } from "snabbdom-jsx"; // eslint-disable-line @typescript-eslint/no-unused-vars
-import { VNode } from "snabbdom/vnode";
+import { VNode } from "snabbdom";
+import { html } from "sprotty"; // eslint-disable-line @typescript-eslint/no-unused-vars
 
 interface SynthesisPickerProps {
     currentId: string;

--- a/packages/klighd-core/src/options/general-panel.tsx
+++ b/packages/klighd-core/src/options/general-panel.tsx
@@ -18,9 +18,8 @@
 /** @jsx html */
 import { RefreshDiagramAction } from "@kieler/klighd-interactive/lib/actions";
 import { inject, injectable, postConstruct } from "inversify";
-import { html } from "snabbdom-jsx"; // eslint-disable-line @typescript-eslint/no-unused-vars
-import { VNode } from "snabbdom/vnode";
-import { Action, CenterAction, IActionDispatcher, RequestExportSvgAction, TYPES } from "sprotty";
+import { VNode } from "snabbdom";
+import { Action, CenterAction, html, IActionDispatcher, RequestExportSvgAction, TYPES } from "sprotty"; // eslint-disable-line @typescript-eslint/no-unused-vars
 import { KlighdFitToScreenAction, RefreshLayoutAction } from "../actions/actions";
 import { DISymbol } from "../di.symbols";
 import { SynthesisPicker } from "./components/synthesis-picker";

--- a/packages/klighd-core/src/options/general-panel.tsx
+++ b/packages/klighd-core/src/options/general-panel.tsx
@@ -111,13 +111,13 @@ export class GeneralPanel extends SidebarPanel {
     render(): VNode {
         return (
             <div>
-                <div classNames="options__section">
-                    <h5 classNames="options__heading">Quick Actions</h5>
-                    <div classNames="options__button-group">
+                <div class-options__section="true">
+                    <h5 class-options__heading="true">Quick Actions</h5>
+                    <div class-options__button-group="true">
                         {this.quickActions.map((action) => (
                             <button
                                 title={action[1]}
-                                classNames="options__icon-button"
+                                class-options__icon-button="true"
                                 on-click={() => this.handleQuickActionClick(action[0])}
                             >
                                 {action[2]}
@@ -125,22 +125,22 @@ export class GeneralPanel extends SidebarPanel {
                         ))}
                     </div>
                 </div>
-                <div classNames="options__section">
-                    <h5 classNames="options__heading">Synthesis</h5>
+                <div class-options__section="true">
+                    <h5 class-options__heading="true">Synthesis</h5>
                     <SynthesisPicker
                         currentId={this.synthesesRegistry.currentSynthesisID}
                         syntheses={this.synthesesRegistry.syntheses}
                         onChange={this.handleSynthesisPickerChange.bind(this)}
                     />
                 </div>
-                <div classNames="options__section">
-                    <h5 classNames="options__heading">Render Options</h5>
+                <div class-options__section="true">
+                    <h5 class-options__heading="true">Render Options</h5>
                     {this.optionsRenderer.renderRenderOptions(
                         this.renderOptionsRegistry.allRenderOptions
                     )}
                 </div>
-                <div classNames="options__section">
-                    <h5 classNames="options__heading">Preferences</h5>
+                <div class-options__section="true">
+                    <h5 class-options__heading="true">Preferences</h5>
                     <CheckOption
                         id="resizeToFit"
                         name="Resize To Fit"

--- a/packages/klighd-core/src/options/general-panel.tsx
+++ b/packages/klighd-core/src/options/general-panel.tsx
@@ -19,18 +19,20 @@
 import { RefreshDiagramAction } from "@kieler/klighd-interactive/lib/actions";
 import { inject, injectable, postConstruct } from "inversify";
 import { VNode } from "snabbdom";
-import { Action, CenterAction, html, IActionDispatcher, RequestExportSvgAction, TYPES } from "sprotty"; // eslint-disable-line @typescript-eslint/no-unused-vars
+import { html, IActionDispatcher, RequestExportSvgAction, TYPES } from "sprotty"; // eslint-disable-line @typescript-eslint/no-unused-vars
+import { Action, CenterAction } from "sprotty-protocol";
 import { KlighdFitToScreenAction, RefreshLayoutAction } from "../actions/actions";
+import { CreateBookmarkAction } from "../bookmarks/bookmark";
 import { DISymbol } from "../di.symbols";
-import { SynthesisPicker } from "./components/synthesis-picker";
+import { FeatherIcon } from '../feather-icons-snabbdom/feather-icons-snabbdom';
+import { PreferencesRegistry, SetPreferencesAction } from "../preferences-registry";
 import { SidebarPanel } from "../sidebar";
 import { SetSynthesisAction } from "../syntheses/actions";
 import { SynthesesRegistry } from "../syntheses/syntheses-registry";
-import { RenderOptionsRegistry } from "./render-options-registry";
-import { OptionsRenderer } from "./options-renderer";
-import { PreferencesRegistry, SetPreferencesAction } from "../preferences-registry";
 import { CheckOption } from "./components/option-inputs";
-import { CreateBookmarkAction } from "../bookmarks/bookmark";
+import { SynthesisPicker } from "./components/synthesis-picker";
+import { OptionsRenderer } from "./options-renderer";
+import { RenderOptionsRegistry } from "./render-options-registry";
 
 /** Type for available quick actions. */
 type PossibleAction = "center" | "fit" | "layout" | "refresh" | "export" | "create-bookmark";
@@ -45,7 +47,7 @@ export class GeneralPanel extends SidebarPanel {
     readonly position = -10;
 
     /** Quick actions reference for this panel */
-    private quickActions: [key: PossibleAction, title: string, icon: VNode, action: Action][];
+    private quickActions: [key: PossibleAction, title: string, iconId: string, action: Action][];
 
     @inject(TYPES.IActionDispatcher) private actionDispatcher: IActionDispatcher;
     @inject(DISymbol.SynthesesRegistry) private synthesesRegistry: SynthesesRegistry;
@@ -64,38 +66,38 @@ export class GeneralPanel extends SidebarPanel {
             [
                 "center",
                 "Center diagram",
-                <i attrs={{ "data-feather": "maximize" }}></i>,
-                new CenterAction([], true),
+                "maximize",
+                CenterAction.create([], { animate: true }),
             ],
             [
                 "fit",
                 "Fit to screen",
-                <i attrs={{ "data-feather": "maximize-2" }}></i>,
-                new KlighdFitToScreenAction(true),
+                "maximize-2",
+                KlighdFitToScreenAction.create(true),
             ],
             [
                 "layout",
                 "Layout diagram",
-                <i attrs={{ "data-feather": "layout" }}></i>,
-                new RefreshLayoutAction(),
+                "layout",
+                RefreshLayoutAction.create(),
             ],
             [
                 "refresh",
                 "Refresh diagram",
-                <i attrs={{ "data-feather": "refresh-cw" }}></i>,
-                new RefreshDiagramAction(),
+                "refresh-cw",
+                RefreshDiagramAction.create(),
             ],
             [
                 "export",
                 "Export as SVG",
-                <i attrs={{ "data-feather": "save" }}></i>,
-                new RequestExportSvgAction(),
+                "save",
+                RequestExportSvgAction.create(),
             ],
             [
                 "create-bookmark",
                 "Bookmark",
-                <i attrs={{ "data-feather": "bookmark" }} />,
-                new CreateBookmarkAction()
+                "bookmark",
+                CreateBookmarkAction.create()
             ],
         ];
     }
@@ -120,7 +122,7 @@ export class GeneralPanel extends SidebarPanel {
                                 class-options__icon-button="true"
                                 on-click={() => this.handleQuickActionClick(action[0])}
                             >
-                                {action[2]}
+                                <FeatherIcon iconId={action[2]}/>
                             </button>
                         ))}
                     </div>
@@ -183,11 +185,11 @@ export class GeneralPanel extends SidebarPanel {
     }
 
     private handleSynthesisPickerChange(newId: string) {
-        this.actionDispatcher.dispatch(new SetSynthesisAction(newId));
+        this.actionDispatcher.dispatch(SetSynthesisAction.create(newId));
     }
 
     private handlePreferenceChange(key: string, newValue: any) {
-        this.actionDispatcher.dispatch(new SetPreferencesAction({ [key]: newValue }));
+        this.actionDispatcher.dispatch(SetPreferencesAction.create({ [key]: newValue }));
     }
 
     private handleQuickActionClick(type: PossibleAction) {
@@ -199,6 +201,6 @@ export class GeneralPanel extends SidebarPanel {
     }
 
     get icon(): VNode {
-        return <i attrs={{ "data-feather": "settings" }}></i>;
+        return <FeatherIcon iconId={"settings"}/>;
     }
 }

--- a/packages/klighd-core/src/options/options-panel.tsx
+++ b/packages/klighd-core/src/options/options-panel.tsx
@@ -22,6 +22,7 @@ import { inject, injectable, postConstruct } from "inversify";
 import { OptionsRegistry } from "./options-registry";
 import { OptionsRenderer } from "./options-renderer";
 import { DISymbol } from "../di.symbols";
+import { FeatherIcon } from '../feather-icons-snabbdom/feather-icons-snabbdom';
 import { SidebarPanel } from "../sidebar";
 
 /** Sidebar panel that displays server provided KLighD options.  */
@@ -56,6 +57,6 @@ export class OptionsPanel extends SidebarPanel {
     }
 
     get icon(): VNode {
-        return <i attrs={{ "data-feather": "sliders" }}></i>
+        return <FeatherIcon iconId={"sliders"}/>
     }
 }

--- a/packages/klighd-core/src/options/options-panel.tsx
+++ b/packages/klighd-core/src/options/options-panel.tsx
@@ -16,8 +16,8 @@
  */
 
 /** @jsx html */
-import { html } from "snabbdom-jsx"; // eslint-disable-line @typescript-eslint/no-unused-vars
-import { VNode } from "snabbdom/vnode";
+import { VNode } from "snabbdom";
+import { html } from "sprotty"; // eslint-disable-line @typescript-eslint/no-unused-vars
 import { inject, injectable, postConstruct } from "inversify";
 import { OptionsRegistry } from "./options-registry";
 import { OptionsRenderer } from "./options-renderer";

--- a/packages/klighd-core/src/options/options-persistence.ts
+++ b/packages/klighd-core/src/options/options-persistence.ts
@@ -17,7 +17,6 @@
 
 import { inject, injectable, postConstruct } from "inversify";
 import {
-    Action,
     ActionHandlerRegistry,
     IActionDispatcher,
     IActionHandler,
@@ -25,6 +24,7 @@ import {
     ICommand,
     TYPES,
 } from "sprotty";
+import { Action } from "sprotty-protocol";
 import { PersistenceStorage } from "../services";
 import {
     ResetLayoutOptionsAction,
@@ -84,8 +84,8 @@ export class OptionsPersistence implements IActionHandler, IActionHandlerInitial
 
     /** Reset all stored options when the storage gets cleared from outside. */
     private handleClear() {
-        this.dispatcher.dispatch(new ResetRenderOptionsAction());
-        this.dispatcher.dispatch(new ResetSynthesisOptionsAction());
-        this.dispatcher.dispatch(new ResetLayoutOptionsAction());
+        this.dispatcher.dispatch(ResetRenderOptionsAction.create());
+        this.dispatcher.dispatch(ResetSynthesisOptionsAction.create());
+        this.dispatcher.dispatch(ResetLayoutOptionsAction.create());
     }
 }

--- a/packages/klighd-core/src/options/options-registry.ts
+++ b/packages/klighd-core/src/options/options-registry.ts
@@ -16,7 +16,8 @@
  */
 
 import { inject, injectable } from "inversify";
-import { Action, ActionHandlerRegistry, IActionHandlerInitializer, ICommand } from "sprotty";
+import { ActionHandlerRegistry, IActionHandlerInitializer, ICommand } from "sprotty";
+import { Action } from "sprotty-protocol";
 import { Registry } from "../base/registry";
 import { Connection, NotificationType } from "../services";
 import {

--- a/packages/klighd-core/src/options/options-renderer.tsx
+++ b/packages/klighd-core/src/options/options-renderer.tsx
@@ -64,13 +64,13 @@ export class OptionsRenderer {
      */
     renderServerOptions(options: AllOptions): VNode {
         return (
-            <div classNames="options">
+            <div class-options="true">
                 {options.actions.length === 0 ? (
                     ""
                 ) : (
-                    <div classNames="options__section">
-                        <h5 classNames="options__heading">Actions</h5>
-                        <div classNames="options__button-group">
+                    <div class-options__section="true">
+                        <h5 class-options__heading="true">Actions</h5>
+                        <div class-options__button-group="true">
                             {this.renderActions(options.actions)}
                         </div>
                     </div>
@@ -78,16 +78,16 @@ export class OptionsRenderer {
                 {options.synthesisOptions.length === 0 ? (
                     ""
                 ) : (
-                    <div classNames="options__section">
-                        <h5 classNames="options__heading">Synthesis Options</h5>
+                    <div class-options__section="true">
+                        <h5 class-options__heading="true">Synthesis Options</h5>
                         {this.renderSynthesisOptions(options.synthesisOptions, null)}
                     </div>
                 )}
                 {options.layoutOptions.length === 0 ? (
                     ""
                 ) : (
-                    <div classNames="options__section">
-                        <h5 classNames="options__heading">Layout Options</h5>
+                    <div class-options__section="true">
+                        <h5 class-options__heading="true">Layout Options</h5>
                         {this.renderLayoutOptions(options.layoutOptions)}
                     </div>
                 )}
@@ -98,7 +98,7 @@ export class OptionsRenderer {
     private renderActions(actions: DisplayedActionData[]): (VNode | "")[] | "" {
         return actions.map((action) => (
             <button
-                classNames="options__button"
+                class-options__button="true"
                 key={action.actionId}
                 title={action.tooltipText}
                 on-click={this.handleActionClick.bind(this, action.actionId)}

--- a/packages/klighd-core/src/options/options-renderer.tsx
+++ b/packages/klighd-core/src/options/options-renderer.tsx
@@ -16,19 +16,9 @@
  */
 
 /** @jsx html */
-import { html } from "snabbdom-jsx"; // eslint-disable-line @typescript-eslint/no-unused-vars
-import { VNode } from "snabbdom/vnode";
 import { inject, injectable } from "inversify";
-import {
-    DisplayedActionData,
-    LayoutOptionUIData,
-    SynthesisOption,
-    RangeOption as RangeOptionData,
-    Type,
-    RenderOption,
-    TransformationOptionType
-} from "./option-models";
-import { IActionDispatcher, TYPES } from "sprotty";
+import { VNode } from "snabbdom";
+import { html, IActionDispatcher, TYPES } from "sprotty"; // eslint-disable-line @typescript-eslint/no-unused-vars
 import {
     PerformOptionsActionAction,
     SetLayoutOptionsAction,
@@ -43,6 +33,15 @@ import {
     SeparatorOption,
     CategoryOption,
 } from "./components/option-inputs";
+import {
+    DisplayedActionData,
+    LayoutOptionUIData,
+    SynthesisOption,
+    RangeOption as RangeOptionData,
+    Type,
+    RenderOption,
+    TransformationOptionType
+} from "./option-models";
 
 // Note: Skipping a JSX children by rendering null or undefined for that child does not work the same way
 // as it works in React. It will render the literals as words. To skip a child return an empty string "".

--- a/packages/klighd-core/src/options/options-renderer.tsx
+++ b/packages/klighd-core/src/options/options-renderer.tsx
@@ -109,7 +109,7 @@ export class OptionsRenderer {
     }
 
     private handleActionClick(actionId: string) {
-        this.actionDispatcher.dispatch(new PerformOptionsActionAction(actionId));
+        this.actionDispatcher.dispatch(PerformOptionsActionAction.create(actionId));
     }
 
     /**
@@ -194,7 +194,7 @@ export class OptionsRenderer {
 
     private handleSynthesisOptionChange(option: SynthesisOption, newValue: any) {
         this.actionDispatcher.dispatch(
-            new SetSynthesisOptionsAction([{ ...option, currentValue: newValue }])
+            SetSynthesisOptionsAction.create([{ ...option, currentValue: newValue }])
         );
     }
 
@@ -246,7 +246,7 @@ export class OptionsRenderer {
 
     private handleLayoutOptionChange(option: LayoutOptionUIData, newValue: any) {
         this.actionDispatcher.dispatch(
-            new SetLayoutOptionsAction([{ optionId: option.optionId, value: newValue }])
+            SetLayoutOptionsAction.create([{ optionId: option.optionId, value: newValue }])
         );
     }
 
@@ -287,6 +287,6 @@ export class OptionsRenderer {
     }
 
     private handleRenderOptionChange(option: RenderOption, newValue: any) {
-        this.actionDispatcher.dispatch(new SetRenderOptionAction(option.id, newValue));
+        this.actionDispatcher.dispatch(SetRenderOptionAction.create(option.id, newValue));
     }
 }

--- a/packages/klighd-core/src/options/render-options-registry.ts
+++ b/packages/klighd-core/src/options/render-options-registry.ts
@@ -16,7 +16,8 @@
  */
 
 import { inject, injectable, postConstruct } from "inversify";
-import { Action, ICommand, UpdateModelAction } from "sprotty";
+import { ICommand } from "sprotty";
+import { Action, UpdateModelAction } from "sprotty-protocol";
 import { Registry } from "../base/registry";
 import { PersistenceStorage } from "../services";
 import { ResetRenderOptionsAction, SetRenderOptionAction } from "./actions";
@@ -274,7 +275,7 @@ export class RenderOptionsRegistry extends Registry {
             this.notifyListeners();
 
         }
-        return new UpdateModelAction([], false, action)
+        return UpdateModelAction.create([], { animate: false, cause: action })
     }
 
     get allRenderOptions(): RenderOption[] {

--- a/packages/klighd-core/src/preferences-registry.ts
+++ b/packages/klighd-core/src/preferences-registry.ts
@@ -16,7 +16,8 @@
  */
 
 import { inject, injectable, postConstruct } from "inversify";
-import { Action, ICommand } from "sprotty";
+import { ICommand } from "sprotty";
+import { Action } from "sprotty-protocol";
 import { Registry } from "./base/registry";
 import { Connection, NotificationType } from "./services";
 
@@ -109,14 +110,23 @@ export class PreferencesRegistry extends Registry {
 }
 
 /** Change the user preferences stored in the `klighd-core` container. */
-export class SetPreferencesAction implements Action {
-    static readonly KIND = "setPreferences";
-    readonly kind = SetPreferencesAction.KIND;
+export interface SetPreferencesAction extends Action {
+    kind: typeof SetPreferencesAction.KIND
+    preferences: Partial<Preferences>
+}
 
-    constructor(readonly preferences: Partial<Preferences>) { }
+export namespace SetPreferencesAction {
+    export const KIND = "setPreferences"
+
+    export function create(preferences: Partial<Preferences>): SetPreferencesAction {
+        return {
+            kind: KIND,
+            preferences,
+        }
+    }
 
     /** Type predicate to narrow an action to this action. */
-    static isThisAction(action: Action): action is SetPreferencesAction {
+    export function isThisAction(action: Action): action is SetPreferencesAction {
         return action.kind === SetPreferencesAction.KIND;
     }
 }

--- a/packages/klighd-core/src/services.ts
+++ b/packages/klighd-core/src/services.ts
@@ -26,7 +26,7 @@
 // https://gitter.im/inversify/InversifyJS?at=5e4ed3645fd3f22ede92d911
 
 import { Container } from "inversify";
-import { ActionMessage } from "sprotty";
+import { ActionMessage } from "sprotty-protocol";
 
 /** All services that are required by the `klighd-core` package and have to be provided externally. */
 interface Services {

--- a/packages/klighd-core/src/sidebar/actions.ts
+++ b/packages/klighd-core/src/sidebar/actions.ts
@@ -15,13 +15,19 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-import { SetUIExtensionVisibilityAction, Action } from "sprotty";
+import { SetUIExtensionVisibilityAction } from "sprotty";
+import { Action } from "sprotty-protocol";
 import { Sidebar } from "./sidebar";
 
 /** Wrapper action around {@link SetUIExtensionVisibilityAction} which shows the sidebar. */
-export class ShowSidebarAction extends SetUIExtensionVisibilityAction {
-    constructor() {
-        super(Sidebar.ID, true);
+export type ShowSidebarAction = SetUIExtensionVisibilityAction
+
+export namespace ShowSidebarAction {
+    export function create():  ShowSidebarAction {
+        return SetUIExtensionVisibilityAction.create({
+            extensionId: Sidebar.ID,
+            visible: true,
+        })
     }
 }
 
@@ -31,9 +37,14 @@ export class ShowSidebarAction extends SetUIExtensionVisibilityAction {
  * panel that should be toggled. If the panel is already shown, it is hidden and
  * the sidebar is closed.
  */
-export class ToggleSidebarPanelAction implements Action {
-    static readonly KIND = "toggleSidebarPanel";
-    readonly kind = ToggleSidebarPanelAction.KIND;
+export interface ToggleSidebarPanelAction extends Action {
+    kind: typeof ToggleSidebarPanelAction.KIND
+    id: string
+    state?: "show" | "hide"
+}
+
+export namespace ToggleSidebarPanelAction {
+    export const KIND = "toggleSidebarPanel";
 
     /**
      * Creates a new {@link ToggleSidebarPanelAction}.
@@ -41,10 +52,16 @@ export class ToggleSidebarPanelAction implements Action {
      * @param state Explicitly sets the new state for the panel. If this parameter is
      * absent, the current state is toggled.
      */
-    constructor(readonly id: string, readonly state?: "show" | "hide") {}
+    export function create(id: string, state?: "show" | "hide"): ToggleSidebarPanelAction {
+        return {
+            kind: KIND,
+            id: id,
+            state: state
+        }
+    }
 
     /** Type predicate to narrow an action to this action. */
-    static isThisAction(action: Action): action is ToggleSidebarPanelAction {
-      return action.kind === ToggleSidebarPanelAction.KIND;
+    export function isThisAction(action: Action): action is ToggleSidebarPanelAction {
+        return action.kind === ToggleSidebarPanelAction.KIND;
     }
 }

--- a/packages/klighd-core/src/sidebar/sidebar-panel-registry.ts
+++ b/packages/klighd-core/src/sidebar/sidebar-panel-registry.ts
@@ -16,7 +16,8 @@
  */
 
 import { injectable, multiInject, optional } from "inversify";
-import { Action, ICommand } from "sprotty";
+import { ICommand } from "sprotty";
+import { Action } from "sprotty-protocol"
 import { Registry } from "../base/registry";
 import { DISymbol } from "../di.symbols";
 import { ToggleSidebarPanelAction } from "./actions";

--- a/packages/klighd-core/src/sidebar/sidebar-panel.ts
+++ b/packages/klighd-core/src/sidebar/sidebar-panel.ts
@@ -29,12 +29,11 @@ export interface ISidebarPanel {
     readonly title: string;
     /**
      * Icon used for the corresponding panel toggle.
-     * For an icon source you should use feather-icons (https://feathericons.com).
+     * For an icon source you should use feather-icons (https://feathericons.com)
+     * and the FeatherIcon method from the folder feather-icons-snabbdom.
      *
-     * Usage example: `<i attrs={{ "data-feather": "settings" }}></i>` where
+     * Usage example: `<FeatherIcon iconId={"settings"}/>` where
      * settings is the name of the icon.
-     *
-     * The `<i>` tag will be replaced with the corresponding svg by feather.
      */
     readonly icon: VNode;
 

--- a/packages/klighd-core/src/sidebar/sidebar-panel.ts
+++ b/packages/klighd-core/src/sidebar/sidebar-panel.ts
@@ -16,7 +16,7 @@
  */
 
 import { injectable } from "inversify";
-import { VNode } from "snabbdom/vnode";
+import { VNode } from "snabbdom";
 
 /**
  * A sidebar panel provides content that is shown by the sidebar.
@@ -52,7 +52,8 @@ export interface ISidebarPanel {
      * Renders this panel content and returns the content as a snabbdom VNode.
      * Learn more about snabbdom and how to use it here:
      * - https://www.npmjs.com/package/snabbdom
-     * - https://www.npmjs.com/package/snabbdom-jsx
+     * - https://www.npmjs.com/package/snabbdom-jsx (package not used anymore, but concept is still
+     * the same)
      */
     render(): VNode;
 }

--- a/packages/klighd-core/src/sidebar/sidebar.tsx
+++ b/packages/klighd-core/src/sidebar/sidebar.tsx
@@ -16,13 +16,12 @@
  */
 
 /** @jsx html */
-import { html } from "snabbdom-jsx"; // eslint-disable-line @typescript-eslint/no-unused-vars
-import { inject, postConstruct } from "inversify";
 import { replace as featherReplace } from "feather-icons";
-import { VNode } from "snabbdom/vnode";
-import { AbstractUIExtension, IActionDispatcher, Patcher, PatcherProvider, TYPES } from "sprotty";
-import { DISymbol } from "../di.symbols";
+import { inject, postConstruct } from "inversify";
+import { VNode } from "snabbdom";
+import { AbstractUIExtension, html, IActionDispatcher, Patcher, PatcherProvider, TYPES } from "sprotty"; // eslint-disable-line @typescript-eslint/no-unused-vars
 import { ShowSidebarAction, ToggleSidebarPanelAction } from "./actions";
+import { DISymbol } from "../di.symbols";
 import { SidebarPanelRegistry } from "./sidebar-panel-registry";
 
 /**

--- a/packages/klighd-core/src/sidebar/sidebar.tsx
+++ b/packages/klighd-core/src/sidebar/sidebar.tsx
@@ -74,11 +74,11 @@ export class Sidebar extends AbstractUIExtension {
         const currentPanel = this.sidebarPanelRegistry.currentPanel;
 
         const content: VNode = (
-            <div classNames="sidebar__content">
-                <div classNames="sidebar__toggle-container">
+            <div class-sidebar__content="true">
+                <div class-sidebar__toggle-container="true">
                     {this.sidebarPanelRegistry.allPanels.map((panel) => (
                         <button
-                            classNames="sidebar__toggle-button"
+                            class-sidebar__toggle-button="true"
                             class-sidebar__toggle-button--active={
                                 this.sidebarPanelRegistry.currentPanelID === panel.id
                             }
@@ -89,8 +89,8 @@ export class Sidebar extends AbstractUIExtension {
                         </button>
                     ))}
                 </div>
-                <h3 classNames="sidebar__title">{currentPanel?.title ?? ""}</h3>
-                <div classNames="sidebar__panel-content">{currentPanel?.render() ?? ""}</div>
+                <h3 class-sidebar__title="true">{currentPanel?.title ?? ""}</h3>
+                <div class-sidebar__panel-content="true">{currentPanel?.render() ?? ""}</div>
             </div>
         );
 

--- a/packages/klighd-core/src/sidebar/sidebar.tsx
+++ b/packages/klighd-core/src/sidebar/sidebar.tsx
@@ -16,7 +16,6 @@
  */
 
 /** @jsx html */
-import { replace as featherReplace } from "feather-icons";
 import { inject, postConstruct } from "inversify";
 import { VNode } from "snabbdom";
 import { AbstractUIExtension, html, IActionDispatcher, Patcher, PatcherProvider, TYPES } from "sprotty"; // eslint-disable-line @typescript-eslint/no-unused-vars
@@ -43,7 +42,7 @@ export class Sidebar extends AbstractUIExtension {
 
     @postConstruct()
     init(): void {
-        this.actionDispatcher.dispatch(new ShowSidebarAction());
+        this.actionDispatcher.dispatch(ShowSidebarAction.create());
         this.patcher = this.patcherProvider.patcher;
 
         // Update the panel if the registry state changes
@@ -97,13 +96,6 @@ export class Sidebar extends AbstractUIExtension {
         // Update panel content with efficient VDOM patching.
         this.oldPanelContentRoot = this.patcher(this.oldPanelContentRoot, content);
 
-        // The feather icon package is not able to return VNode. Therefore,
-        // the icons can not be directly rendered by Snabbdom. To avoid this,
-        // icons in the V-DOM can be placed with a <i data-feather="..."></> tag.
-        // This call replaces the icons after the V-DOM has been patched into the DOM.
-        // See: https://github.com/feathericons/feather#featherreplaceattrs
-        featherReplace();
-
         // Show or hide the panel
         if (currentPanel) {
             this.containerElement.classList.add("sidebar--open");
@@ -131,7 +123,7 @@ export class Sidebar extends AbstractUIExtension {
     }
 
     private handlePanelButtonClick(id: string) {
-        this.actionDispatcher.dispatch(new ToggleSidebarPanelAction(id));
+        this.actionDispatcher.dispatch(ToggleSidebarPanelAction.create(id));
     }
 
     /**
@@ -146,7 +138,7 @@ export class Sidebar extends AbstractUIExtension {
             // See for information on detecting "click outside": https://stackoverflow.com/a/64665817/7569889
             if (!currentPanelID || e.composedPath().includes(containerElement)) return;
 
-            this.actionDispatcher.dispatch(new ToggleSidebarPanelAction(currentPanelID, "hide"));
+            this.actionDispatcher.dispatch(ToggleSidebarPanelAction.create(currentPanelID, "hide"));
         });
     }
 }

--- a/packages/klighd-core/src/skgraph-model-renderer.ts
+++ b/packages/klighd-core/src/skgraph-model-renderer.ts
@@ -3,7 +3,7 @@
  *
  * http://rtsys.informatik.uni-kiel.de/kieler
  *
- * Copyright 2020 by
+ * Copyright 2020-2021 by
  * + Kiel University
  *   + Department of Computer Science
  *     + Real-Time and Embedded Systems Group
@@ -16,7 +16,8 @@
  */
 
 import { VNode } from 'snabbdom';
-import { IVNodePostprocessor, ModelRenderer, RenderingTargetKind, SParentElement, Viewport, ViewRegistry } from 'sprotty';
+import { IVNodePostprocessor, ModelRenderer, RenderingTargetKind, SParentElement, ViewRegistry } from 'sprotty';
+import { Viewport } from 'sprotty-protocol';
 import { DepthMap } from './depth-map';
 import { RenderOptionsRegistry } from './options/render-options-registry';
 import { KRenderingLibrary, EDGE_TYPE, LABEL_TYPE, NODE_TYPE, PORT_TYPE, SKGraphElement } from './skgraph-models';

--- a/packages/klighd-core/src/skgraph-model-renderer.ts
+++ b/packages/klighd-core/src/skgraph-model-renderer.ts
@@ -15,8 +15,8 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-import { VNode } from 'snabbdom/vnode';
-import { IVNodePostprocessor, ModelRenderer, RenderingTargetKind, SParentElement, Viewport, ViewRegistry } from 'sprotty/lib';
+import { VNode } from 'snabbdom';
+import { IVNodePostprocessor, ModelRenderer, RenderingTargetKind, SParentElement, Viewport, ViewRegistry } from 'sprotty';
 import { DepthMap } from './depth-map';
 import { RenderOptionsRegistry } from './options/render-options-registry';
 import { KRenderingLibrary, EDGE_TYPE, LABEL_TYPE, NODE_TYPE, PORT_TYPE, SKGraphElement } from './skgraph-models';
@@ -45,14 +45,14 @@ export class SKGraphModelRenderer extends ModelRenderer {
      *
      * @param element The element to render the children from.
      */
-    renderChildAreaChildren(element: Readonly<SParentElement> & SKGraphElement, args?: Record<string, unknown>): VNode[] {
+    renderChildAreaChildren(element: Readonly<SParentElement> & SKGraphElement): VNode[] {
         element.areChildAreaChildrenRendered = true
         return element.children
             .filter(child =>
                 child.type === NODE_TYPE ||
                 child.type === EDGE_TYPE)
             .map((child): VNode | undefined => {
-                return this.renderElement(child, args)
+                return this.renderElement(child)
             })
             .filter(vnode => vnode !== undefined) as VNode[]
     }
@@ -62,14 +62,14 @@ export class SKGraphModelRenderer extends ModelRenderer {
      *
      * @param element The element to render the children from.
      */
-    renderNonChildAreaChildren(element: Readonly<SParentElement> & SKGraphElement, args?: Record<string, unknown>): VNode[] {
+    renderNonChildAreaChildren(element: Readonly<SParentElement> & SKGraphElement): VNode[] {
         element.areNonChildAreaChildrenRendered = true
         return element.children
             .filter(child =>
                 child.type === PORT_TYPE ||
                 child.type === LABEL_TYPE)
             .map((child): VNode | undefined => {
-                return this.renderElement(child, args)
+                return this.renderElement(child)
             })
             .filter(vnode => vnode !== undefined) as VNode[]
     }

--- a/packages/klighd-core/src/skgraph-models.ts
+++ b/packages/klighd-core/src/skgraph-models.ts
@@ -16,7 +16,7 @@
  */
 
 import { KEdge, KGraphData, KGraphElement, KNode } from '@kieler/klighd-interactive/lib/constraint-classes';
-import { Bounds, boundsFeature, moveFeature, Point, popupFeature, RectangularPort, RGBColor, selectFeature, SLabel, SModelElement } from 'sprotty/lib';
+import { Bounds, boundsFeature, moveFeature, Point, popupFeature, RectangularPort, RGBColor, selectFeature, SLabel, SModelElement } from 'sprotty';
 
 /**
  * This is the superclass of all elements of a graph such as nodes, edges, ports,

--- a/packages/klighd-core/src/syntheses/actions.ts
+++ b/packages/klighd-core/src/syntheses/actions.ts
@@ -15,7 +15,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-import { Action } from "sprotty";
+import { Action } from "sprotty-protocol";
 
 /** Data sent to the client for setting the available syntheses. */
 export interface SetSynthesesActionData {
@@ -26,27 +26,43 @@ export interface SetSynthesesActionData {
 }
 
 /** Sent from the server to the client to send a list of all available syntheses for the current model. */
-export class SetSynthesesAction implements Action {
-    static readonly KIND: string = "setSyntheses";
-    readonly kind = SetSynthesesAction.KIND;
+export interface SetSynthesesAction extends Action {
+    kind: typeof SetSynthesesAction.KIND
+    syntheses: SetSynthesesActionData[]
+}
 
-    constructor(public readonly syntheses: SetSynthesesActionData[]) {}
+export namespace SetSynthesesAction {
+    export const KIND = "setSyntheses"
 
-    /** Type predicate to narrow an action to this action. */
-    static isThisAction(action: Action): action is SetSynthesesAction {
+    export function create(syntheses: SetSynthesesActionData[]): SetSynthesesAction {
+        return {
+            kind: KIND,
+            syntheses,
+        }
+    }
+
+    export function isThisAction(action: Action): action is SetSynthesesAction {
         return action.kind === SetSynthesesAction.KIND;
     }
 }
 
 /** Sent from the client to the server to request a new diagram with the given synthesis. */
-export class SetSynthesisAction implements Action {
-    static readonly KIND: string = "setSynthesis";
-    readonly kind = SetSynthesisAction.KIND;
+export interface SetSynthesisAction extends Action {
+    kind: typeof SetSynthesisAction.KIND
+    id: string
+}
 
-    constructor(public readonly id: string) {}
+export namespace SetSynthesisAction {
+    export const KIND = "setSynthesis"
 
-    /** Type predicate to narrow an action to this action. */
-    static isThisAction(action: Action): action is SetSynthesisAction {
+    export function create(id: string): SetSynthesisAction {
+        return {
+            kind: KIND,
+            id,
+        }
+    }
+
+    export function isThisAction(action: Action): action is SetSynthesisAction {
         return action.kind === SetSynthesisAction.KIND;
     }
 }

--- a/packages/klighd-core/src/syntheses/syntheses-registry.ts
+++ b/packages/klighd-core/src/syntheses/syntheses-registry.ts
@@ -15,7 +15,8 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 import { injectable } from "inversify";
-import { Action, ICommand } from "sprotty";
+import { ICommand } from "sprotty";
+import { Action } from "sprotty-protocol";
 import { Registry } from "../base/registry";
 import { SetSynthesesAction, SetSynthesesActionData, SetSynthesisAction } from "./actions";
 

--- a/packages/klighd-core/src/update/update-depthmap-model.ts
+++ b/packages/klighd-core/src/update/update-depthmap-model.ts
@@ -17,17 +17,26 @@
 
 import { inject, injectable } from 'inversify';
 import { Command, TYPES } from 'sprotty'
-import { Action } from 'sprotty';
 import { CommandExecutionContext, CommandReturn } from 'sprotty';
+import { Action } from 'sprotty-protocol';
 import { DepthMap } from '../depth-map';
 
 /**
- * Simple UpdateDepthMapAction Fires the UpdateDepthMapModelCommand
+ * Simple UpdateDepthMapAction fires the UpdateDepthMapModelCommand
  * is created whenever a updateModelAction or a setModelAction is present
  */
-export class UpdateDepthMapModelAction implements Action {
-    static readonly KIND = 'updateDepthMapModel';
-    readonly kind = UpdateDepthMapModelAction.KIND;
+export interface UpdateDepthMapModelAction extends Action {
+    kind: typeof UpdateDepthMapModelAction.KIND
+}
+
+export namespace UpdateDepthMapModelAction {
+    export const KIND = 'updateDepthMapModel'
+
+    export function create(): UpdateDepthMapModelAction {
+        return {
+            kind: KIND,
+        }
+    }
 }
 
 /**

--- a/packages/klighd-core/src/views-common.ts
+++ b/packages/klighd-core/src/views-common.ts
@@ -15,7 +15,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-import { Bounds, Point, toDegrees } from 'sprotty/lib';
+import { Bounds, Point, toDegrees } from 'sprotty';
 import { SKGraphModelRenderer } from './skgraph-model-renderer';
 import {
     Decoration, HorizontalAlignment, KColoring, KHorizontalAlignment, KLineCap, KLineJoin, KLineStyle, KPolyline, KPosition, KRendering,

--- a/packages/klighd-core/src/views-common.ts
+++ b/packages/klighd-core/src/views-common.ts
@@ -3,7 +3,7 @@
  *
  * http://rtsys.informatik.uni-kiel.de/kieler
  *
- * Copyright 2019,2020 by
+ * Copyright 2019-2021 by
  * + Kiel University
  *   + Department of Computer Science
  *     + Real-Time and Embedded Systems Group
@@ -15,7 +15,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-import { Bounds, Point, toDegrees } from 'sprotty';
+import { Bounds, Point, toDegrees } from 'sprotty-protocol';
 import { SKGraphModelRenderer } from './skgraph-model-renderer';
 import {
     Decoration, HorizontalAlignment, KColoring, KHorizontalAlignment, KLineCap, KLineJoin, KLineStyle, KPolyline, KPosition, KRendering,

--- a/packages/klighd-core/src/views-rendering.tsx
+++ b/packages/klighd-core/src/views-rendering.tsx
@@ -15,9 +15,8 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 /** @jsx svg */
-import { svg } from 'snabbdom-jsx'; // eslint-disable-line @typescript-eslint/no-unused-vars
-import { VNode } from 'snabbdom/vnode';
-import { Bounds } from 'sprotty';
+import { VNode } from 'snabbdom';
+import { Bounds, svg } from 'sprotty'; // eslint-disable-line @typescript-eslint/no-unused-vars
 import { KGraphData, KNode } from '@kieler/klighd-interactive/lib/constraint-classes';
 import { KlighdInteractiveMouseListener } from '@kieler/klighd-interactive/lib/klighd-interactive-mouselistener';
 import { DetailLevel } from './depth-map';
@@ -755,9 +754,9 @@ export function renderSingleSVGRect(x: number | undefined, y: number | undefined
             ...(kShadow ? {} : {'stroke-width': lineStyles.lineWidth}),
             ...(kShadow ? {} : {'stroke-dasharray': lineStyles.dashArray}),
             ...(kShadow ? {} : {'stroke-miterlimit': lineStyles.miterLimit}),
-            'opacity': kShadow ? colorStyles.opacity ? colorStyles.opacity * 0.1 : 0.1 : colorStyles.opacity,
+            'opacity': kShadow ? colorStyles.opacity ? String(Number(colorStyles.opacity) * 0.1) : '0.1' : colorStyles.opacity,
             ...(kShadow ? {} : {'stroke-opacity': colorStyles.foreground.opacity}),
-            'fill-opacity': kShadow ? 1 : colorStyles.background.opacity
+            ...(kShadow || colorStyles.background.opacity ? {'fill-opacity': kShadow ? '1' : colorStyles.background.opacity} : {})
         }}
         {...(kShadow ? {} : {stroke: colorStyles.foreground.color})}
         {...(kShadow ? {fill:'rgb(0,0,0)'} : {fill: colorStyles.background.color})}
@@ -797,7 +796,7 @@ export function renderSingleSVGImage(x: number | undefined, y: number | undefine
             width={bounds.width}
             height={bounds.height}
             style={{
-                'opacity': 0.1
+                'opacity': '0.1'
             }}
             fill='rgb(0,0,0)'
         />
@@ -849,9 +848,9 @@ export function renderSingleSVGArc(x: number | undefined, y: number | undefined,
             ...(kShadow ? {} : {'stroke-width': lineStyles.lineWidth}),
             ...(kShadow ? {} : {'stroke-dasharray': lineStyles.dashArray}),
             ...(kShadow ? {} : {'stroke-miterlimit': lineStyles.miterLimit}),
-            'opacity': kShadow ? colorStyles.opacity ? colorStyles.opacity * 0.1 : 0.1 : colorStyles.opacity,
+            'opacity': kShadow ? colorStyles.opacity ? String(Number(colorStyles.opacity) * 0.1) : '0.1' : colorStyles.opacity,
             ...(kShadow ? {} : {'stroke-opacity': colorStyles.foreground.opacity}),
-            'fill-opacity': kShadow ? 1 : colorStyles.background.opacity
+            ...(kShadow || colorStyles.background.opacity ? {'fill-opacity': kShadow ? '1' : colorStyles.background.opacity} : {})
         }}
         {...(kShadow ? {} : {stroke: colorStyles.foreground.color})}
         {...(kShadow ? {fill:'rgb(0,0,0)'} : {fill: colorStyles.background.color})}
@@ -899,9 +898,9 @@ export function renderSingleSVGEllipse(x: number | undefined, y: number | undefi
             ...(kShadow ? {} : {'stroke-width': lineStyles.lineWidth}),
             ...(kShadow ? {} : {'stroke-dasharray': lineStyles.dashArray}),
             ...(kShadow ? {} : {'stroke-miterlimit': lineStyles.miterLimit}),
-            'opacity': kShadow ? colorStyles.opacity ? colorStyles.opacity * 0.1 : 0.1 : colorStyles.opacity,
+            'opacity': kShadow ? colorStyles.opacity ? String(Number(colorStyles.opacity) * 0.1) : '0.1' : colorStyles.opacity,
             ...(kShadow ? {} : {'stroke-opacity': colorStyles.foreground.opacity}),
-            'fill-opacity': kShadow ? 1 : colorStyles.background.opacity
+            ...(kShadow || colorStyles.background.opacity ? {'fill-opacity': kShadow ? '1' : colorStyles.background.opacity} : {})
         }}
         {...(kShadow ? {} : {stroke: colorStyles.foreground.color})}
         {...(kShadow ? {fill:'rgb(0,0,0)'} : {fill: colorStyles.background.color})}
@@ -947,9 +946,9 @@ export function renderSingleSVGLine(x: number | undefined, y: number | undefined
             ...(kShadow ? {} : {'stroke-width': lineStyles.lineWidth}),
             ...(kShadow ? {} : {'stroke-dasharray': lineStyles.dashArray}),
             ...(kShadow ? {} : {'stroke-miterlimit': lineStyles.miterLimit}),
-            'opacity': kShadow ? colorStyles.opacity ? colorStyles.opacity * 0.1 : 0.1 : colorStyles.opacity,
+            'opacity': kShadow ? colorStyles.opacity ? String(Number(colorStyles.opacity) * 0.1) : '0.1' : colorStyles.opacity,
             ...(kShadow ? {} : {'stroke-opacity': colorStyles.foreground.opacity}),
-            'fill-opacity': kShadow ? 1 : colorStyles.background.opacity
+            ...(kShadow || colorStyles.background.opacity ? {'fill-opacity': kShadow ? '1' : colorStyles.background.opacity} : {})
         }}
         {...(kShadow ? {} : {stroke: colorStyles.foreground.color})}
         {...(kShadow ? {fill:'rgb(0,0,0)'} : {fill: colorStyles.background.color})}

--- a/packages/klighd-core/src/views-rendering.tsx
+++ b/packages/klighd-core/src/views-rendering.tsx
@@ -16,7 +16,8 @@
  */
 /** @jsx svg */
 import { VNode } from 'snabbdom';
-import { Bounds, svg } from 'sprotty'; // eslint-disable-line @typescript-eslint/no-unused-vars
+import { svg } from 'sprotty'; // eslint-disable-line @typescript-eslint/no-unused-vars
+import { Bounds } from 'sprotty-protocol';
 import { KGraphData, KNode } from '@kieler/klighd-interactive/lib/constraint-classes';
 import { KlighdInteractiveMouseListener } from '@kieler/klighd-interactive/lib/klighd-interactive-mouselistener';
 import { DetailLevel } from './depth-map';

--- a/packages/klighd-core/src/views-styles.tsx
+++ b/packages/klighd-core/src/views-styles.tsx
@@ -15,9 +15,8 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 /** @jsx svg */
-import { svg } from 'snabbdom-jsx'; // eslint-disable-line @typescript-eslint/no-unused-vars
-import { VNode } from 'snabbdom/vnode';
-import { getZoom, isSelectable } from 'sprotty';
+import { VNode } from 'snabbdom';
+import { getZoom, isSelectable, svg } from 'sprotty'; // eslint-disable-line @typescript-eslint/no-unused-vars
 import { MinimumLineWidth, UseMinimumLineWidth } from './options/render-options-registry';
 import { SKGraphModelRenderer } from './skgraph-model-renderer';
 import {
@@ -93,7 +92,7 @@ export const DEFAULT_CORNER_WIDTH = 0
 export const DEFAULT_CORNER_HEIGHT = 0
 export const DEFAULT_LINE_CAP_SVG = 'butt'
 export const DEFAULT_LINE_JOIN_SVG = 'miter'
-export const DEFAULT_MITER_LIMIT_SVG = 4
+export const DEFAULT_MITER_LIMIT_SVG = '4'
 /**
  * Data class to hold each possible KStyle of any rendering. Defaults each style to undefined or its default value from PNodeController.java
  */
@@ -385,14 +384,14 @@ export function colorDefinition(colorId: string, start: ColorStyle, end: ColorSt
         offset={0}
         style={{
             'stop-color': start.color,
-            'stop-opacity': start.opacity
+            ...(start.opacity ? {'stop-opacity': start.opacity} : {})
         }}
     />
     const endColorStop = <stop
         offset={1}
         style={{
             'stop-color': end.color,
-            'stop-opacity': end.opacity
+            ...(end.opacity ? {'stop-opacity': end.opacity} : {})
         }}
     />
     const angleFloat = angle === undefined ? 0 : angle
@@ -533,7 +532,7 @@ export function getSvgColorStyles(styles: KStyles, context: SKGraphModelRenderer
         return {
             foreground: grayedOutColor,
             background: background === undefined ? DEFAULT_FILL : grayedOutColor,
-            opacity: parent.opacity
+            opacity: String(parent.opacity)
         }
     }
 
@@ -542,14 +541,14 @@ export function getSvgColorStyles(styles: KStyles, context: SKGraphModelRenderer
         return {
             foreground: grayedOutColor,
             background: background === undefined ? DEFAULT_FILL : { color: 'gainsboro', opacity: '255' },
-            opacity: parent.opacity
+            opacity: String(parent.opacity)
         }
     }
 
     return {
         foreground: foreground === undefined ? DEFAULT_FOREGROUND : foreground,
         background: background === undefined ? DEFAULT_FILL : background,
-        opacity: parent.opacity
+        opacity: String(parent.opacity)
     }
 }
 
@@ -661,7 +660,7 @@ export function getSvgLineStyles(styles: KStyles, target: SKGraphElement, contex
         // always contain the miterLimit style to be set to 10, even though it is not intended by the creator of the KGraph model and it would not
         // even make any difference in the rendering. Here I cannot distinguish if the model creator really wanted to have the specific miter limit of 10
         // or if he just does not care. As the first case seems rare, I prefer a cleaner resulting svg here.
-        miterLimit: lineJoin !== 'miter' || miterLimit === DEFAULT_MITER_LIMIT_SVG || miterLimit === DEFAULT_MITER_LIMIT ? undefined : miterLimit
+        miterLimit: lineJoin !== 'miter' || String(miterLimit) === DEFAULT_MITER_LIMIT_SVG || miterLimit === DEFAULT_MITER_LIMIT ? undefined : String(miterLimit)
     }
 }
 
@@ -706,7 +705,7 @@ export interface ColorStyle {
 export interface ColorStyles {
     foreground: ColorStyle,
     background: ColorStyle,
-    opacity: number
+    opacity: string
 }
 
 /**
@@ -717,7 +716,7 @@ export interface LineStyles {
     lineCap: 'butt' | 'round' | 'square' | undefined,
     lineJoin: 'bevel' | 'miter' | 'round' | undefined,
     dashArray: string | undefined,
-    miterLimit: number | undefined
+    miterLimit: string | undefined
 }
 
 /**

--- a/packages/klighd-core/src/views.tsx
+++ b/packages/klighd-core/src/views.tsx
@@ -20,7 +20,7 @@ import { renderConstraints, renderInteractiveLayout } from '@kieler/klighd-inter
 import { KlighdInteractiveMouseListener } from '@kieler/klighd-interactive/lib/klighd-interactive-mouselistener';
 import { inject, injectable } from 'inversify';
 import { VNode } from 'snabbdom';
-import { findParentByFeature, isViewport, IView, RenderingContext, SGraph, SGraphFactory, svg, TYPES } from 'sprotty'; // eslint-disable-line @typescript-eslint/no-unused-vars
+import { findParentByFeature, isViewport, IView, RenderingContext, SGraph, svg } from 'sprotty'; // eslint-disable-line @typescript-eslint/no-unused-vars
 import { DepthMap, DetailLevel } from './depth-map';
 import { DISymbol } from './di.symbols';
 import { overpass_mono_regular_style, overpass_regular_style } from './fonts/overpass';
@@ -86,7 +86,6 @@ export class KNodeView implements IView {
 
     @inject(KlighdInteractiveMouseListener) mListener: KlighdInteractiveMouseListener
     @inject(DISymbol.RenderOptionsRegistry) protected renderOptionsRegistry: RenderOptionsRegistry
-    @inject(TYPES.IModelFactory) protected graphFactory: SGraphFactory
 
     render(node: SKNode, context: RenderingContext): VNode | undefined {
         // Add new level to title and position array for correct placement of titles

--- a/packages/klighd-core/src/views.tsx
+++ b/packages/klighd-core/src/views.tsx
@@ -15,14 +15,12 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 /** @jsx svg */
-import { svg } from 'snabbdom-jsx'; // eslint-disable-line @typescript-eslint/no-unused-vars
-import { VNode } from 'snabbdom/vnode';
-
 import { isChildSelected } from '@kieler/klighd-interactive/lib/helper-methods';
 import { renderConstraints, renderInteractiveLayout } from '@kieler/klighd-interactive/lib/interactive-view';
 import { KlighdInteractiveMouseListener } from '@kieler/klighd-interactive/lib/klighd-interactive-mouselistener';
 import { inject, injectable } from 'inversify';
-import { findParentByFeature, isViewport, IView, RenderingContext, SGraph, SGraphFactory, SGraphView, TYPES } from 'sprotty/lib';
+import { VNode } from 'snabbdom';
+import { findParentByFeature, isViewport, IView, RenderingContext, SGraph, SGraphFactory, SGraphView, svg, TYPES } from 'sprotty'; // eslint-disable-line @typescript-eslint/no-unused-vars
 import { DepthMap, DetailLevel } from './depth-map';
 import { DISymbol } from './di.symbols';
 import { overpass_mono_regular_style, overpass_regular_style } from './fonts/overpass';
@@ -37,11 +35,11 @@ import { KStyles } from './views-styles';
  * Extends the SGraphView by initializing the context for KGraph rendering.
  */
 @injectable()
-export class SKGraphView extends SGraphView {
+export class SKGraphView<IRenderingArgs> extends SGraphView<IRenderingArgs> {
 
     @inject(DISymbol.RenderOptionsRegistry) protected renderOptionsRegistry: RenderOptionsRegistry
 
-    render(model: Readonly<SGraph>, context: RenderingContext): VNode {
+    render(model: Readonly<SGraph>, context: RenderingContext, args?: IRenderingArgs): VNode {
         const ctx = context as SKGraphModelRenderer
         ctx.renderingDefs = new Map
         ctx.renderingDefs.set("font", fontDefinition())
@@ -70,7 +68,7 @@ export class SKGraphView extends SGraphView {
         } else {
             ctx.depthMap = undefined
         }
-        return super.render(model, context)
+        return super.render(model, context, args)
     }
 }
 

--- a/packages/klighd-core/src/views.tsx
+++ b/packages/klighd-core/src/views.tsx
@@ -20,7 +20,7 @@ import { renderConstraints, renderInteractiveLayout } from '@kieler/klighd-inter
 import { KlighdInteractiveMouseListener } from '@kieler/klighd-interactive/lib/klighd-interactive-mouselistener';
 import { inject, injectable } from 'inversify';
 import { VNode } from 'snabbdom';
-import { findParentByFeature, isViewport, IView, RenderingContext, SGraph, SGraphFactory, SGraphView, svg, TYPES } from 'sprotty'; // eslint-disable-line @typescript-eslint/no-unused-vars
+import { findParentByFeature, isViewport, IView, RenderingContext, SGraph, SGraphFactory, svg, TYPES } from 'sprotty'; // eslint-disable-line @typescript-eslint/no-unused-vars
 import { DepthMap, DetailLevel } from './depth-map';
 import { DISymbol } from './di.symbols';
 import { overpass_mono_regular_style, overpass_regular_style } from './fonts/overpass';
@@ -35,11 +35,11 @@ import { KStyles } from './views-styles';
  * Extends the SGraphView by initializing the context for KGraph rendering.
  */
 @injectable()
-export class SKGraphView<IRenderingArgs> extends SGraphView<IRenderingArgs> {
+export class SKGraphView implements IView {
 
     @inject(DISymbol.RenderOptionsRegistry) protected renderOptionsRegistry: RenderOptionsRegistry
 
-    render(model: Readonly<SGraph>, context: RenderingContext, args?: IRenderingArgs): VNode {
+    render(model: Readonly<SGraph>, context: RenderingContext): VNode {
         const ctx = context as SKGraphModelRenderer
         ctx.renderingDefs = new Map
         ctx.renderingDefs.set("font", fontDefinition())
@@ -68,7 +68,13 @@ export class SKGraphView<IRenderingArgs> extends SGraphView<IRenderingArgs> {
         } else {
             ctx.depthMap = undefined
         }
-        return super.render(model, context, args)
+
+        const transform = `scale(${model.zoom}) translate(${-model.scroll.x},${-model.scroll.y})`;
+        return <svg class-sprotty-graph={true}>
+            <g transform={transform}>
+                {context.renderChildren(model)}
+            </g>
+        </svg>;
     }
 }
 

--- a/packages/klighd-interactive/package.json
+++ b/packages/klighd-interactive/package.json
@@ -21,7 +21,7 @@
     "publish:next": "yarn publish --new-version \"$(semver $npm_package_version -i minor)-next.$(git rev-parse --short HEAD)\" --tag next --no-git-tag-version"
   },
   "dependencies": {
-    "sprotty": "0.9.0"
+    "sprotty": "0.10.0"
   },
   "devDependencies": {
     "semver": "^7.3.5"

--- a/packages/klighd-interactive/package.json
+++ b/packages/klighd-interactive/package.json
@@ -21,7 +21,7 @@
     "publish:next": "yarn publish --new-version \"$(semver $npm_package_version -i minor)-next.$(git rev-parse --short HEAD)\" --tag next --no-git-tag-version"
   },
   "dependencies": {
-    "sprotty": "0.10.0"
+    "sprotty": "0.11.1"
   },
   "devDependencies": {
     "semver": "^7.3.5"

--- a/packages/klighd-interactive/src/actions.ts
+++ b/packages/klighd-interactive/src/actions.ts
@@ -3,7 +3,7 @@
  *
  * http://rtsys.informatik.uni-kiel.de/kieler
  *
- * Copyright 2020 by
+ * Copyright 2020-2021 by
  * + Kiel University
  *   + Department of Computer Science
  *     + Real-Time and Embedded Systems Group
@@ -15,24 +15,41 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-import { Action } from 'sprotty';
+import { Action } from 'sprotty-protocol';
 import { DeleteConstraint } from './layered/constraint-types';
 
 /**
  * A sprotty action to refresh the diagram. Send from client to server.
  */
-export class RefreshDiagramAction implements Action {
-    static readonly KIND: string = 'refreshDiagram'
-    readonly kind = RefreshDiagramAction.KIND
+export interface RefreshDiagramAction extends Action {
+    kind: typeof RefreshDiagramAction.KIND
+}
+
+export namespace RefreshDiagramAction {
+    export const KIND = 'refreshDiagram'
+
+    export function create(): RefreshDiagramAction {
+        return {
+            kind: KIND,
+        }
+    }
 }
 
 /**
  * A sprotty action to delete a constraint on a specific node.
  */
-export class DeleteConstraintAction implements Action {
-    static readonly KIND: string = 'deleteStaticConstraint'
-    readonly kind = DeleteConstraintAction.KIND
+export interface DeleteConstraintAction extends Action {
+    kind: typeof DeleteConstraintAction.KIND
+    constraint: DeleteConstraint
+}
 
-    constructor(public readonly constraint: DeleteConstraint) {
+export namespace DeleteConstraintAction {
+    export const KIND = 'deleteStaticConstraint'
+
+    export function create(constraint: DeleteConstraint): DeleteConstraintAction {
+        return {
+            kind: KIND,
+            constraint,
+        }
     }
 }

--- a/packages/klighd-interactive/src/actions.ts
+++ b/packages/klighd-interactive/src/actions.ts
@@ -15,7 +15,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-import { Action } from 'sprotty/lib/base/actions/action';
+import { Action } from 'sprotty';
 import { DeleteConstraint } from './layered/constraint-types';
 
 /**

--- a/packages/klighd-interactive/src/constraint-classes.ts
+++ b/packages/klighd-interactive/src/constraint-classes.ts
@@ -15,7 +15,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-import { moveFeature, Point, RectangularNode, SEdge, selectFeature, SParentElement } from 'sprotty/lib';
+import { moveFeature, Point, RectangularNode, SEdge, selectFeature, SParentElement } from 'sprotty';
 
 /**
  * This is the superclass of all elements of a graph such as nodes, edges, ports,

--- a/packages/klighd-interactive/src/constraint-classes.ts
+++ b/packages/klighd-interactive/src/constraint-classes.ts
@@ -3,7 +3,7 @@
  *
  * http://rtsys.informatik.uni-kiel.de/kieler
  *
- * Copyright 2019, 2020 by
+ * Copyright 2019-2021 by
  * + Kiel University
  *   + Department of Computer Science
  *     + Real-Time and Embedded Systems Group
@@ -15,7 +15,8 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-import { moveFeature, Point, RectangularNode, SEdge, selectFeature, SParentElement } from 'sprotty';
+import { moveFeature, RectangularNode, SEdge, selectFeature, SParentElement } from 'sprotty';
+import { Point } from 'sprotty-protocol';
 
 /**
  * This is the superclass of all elements of a graph such as nodes, edges, ports,

--- a/packages/klighd-interactive/src/helper-methods.ts
+++ b/packages/klighd-interactive/src/helper-methods.ts
@@ -15,7 +15,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-import { SNode } from "sprotty/lib/graph/sgraph"
+import { SNode } from "sprotty"
 import { KNode } from "./constraint-classes"
 
 /**

--- a/packages/klighd-interactive/src/interactive-view-objects.tsx
+++ b/packages/klighd-interactive/src/interactive-view-objects.tsx
@@ -15,8 +15,8 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 /** @jsx svg */
-import { svg } from 'snabbdom-jsx'; // eslint-disable-line @typescript-eslint/no-unused-vars
-import { VNode } from 'snabbdom/vnode';
+import { VNode } from 'snabbdom';
+import { svg } from 'sprotty'; // eslint-disable-line @typescript-eslint/no-unused-vars
 import { Direction } from './constraint-classes';
 import { lockPath, arrowVertical, arrowHorizontal } from './svg-path';
 
@@ -64,7 +64,7 @@ export function createVerticalLine(mid: number, top: number, bot: number, direct
                     y2={(direction === Direction.RIGHT || direction === Direction.LEFT || direction === Direction.UNDEFINED) ? bot : mid}
                     fill='none'
                     stroke='grey'
-                    style={{ 'stroke-dasharray': 4 }}
+                    style={{ 'stroke-dasharray': '4' }}
                 />
             </g>
 }
@@ -86,7 +86,7 @@ export function renderCircle(fill: boolean, x: number, y: number, forbidden: boo
                     r="2"
                     stroke={color}
                     fill={fill ? color : "none"}
-                    style={{ 'stroke-width': 0.5 }}
+                    style={{ 'stroke-width': '0.5' }}
                 />
             </g>
 }

--- a/packages/klighd-interactive/src/interactive-view.tsx
+++ b/packages/klighd-interactive/src/interactive-view.tsx
@@ -15,13 +15,12 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 /** @jsx svg */
-import { svg } from 'snabbdom-jsx'; // eslint-disable-line @typescript-eslint/no-unused-vars
-import { VNode } from "snabbdom/vnode";
+import { VNode } from "snabbdom";
+import { svg } from 'sprotty'; // eslint-disable-line @typescript-eslint/no-unused-vars
 import { KNode } from './constraint-classes';
 import { filterKNodes } from './helper-methods';
 import { renderHierarchyLevel as renderHierarchyLevelLayered, renderLayeredConstraint } from './layered/layered-interactive-view';
 import { renderHierarchyLevel as renderHierarchyLevelRectPacking, renderRectPackConstraint } from './rect-packing/rect-packing-interactive-view';
-import { isUndefined } from 'util';
 
 /**
  * Visualize the layers and available positions in the graph
@@ -31,7 +30,7 @@ export function renderInteractiveLayout(root: KNode): VNode {
     // Filter KNodes
     const nodes = filterKNodes(root.children)
     let result = undefined
-    if (isUndefined(root.properties.algorithm) || root.properties.algorithm.endsWith('layered')) {
+    if (root.properties.algorithm === undefined || root.properties.algorithm.endsWith('layered')) {
         result = renderHierarchyLevelLayered(nodes)
     } else if (root.properties.algorithm.endsWith('rectpacking')) {
         result = renderHierarchyLevelRectPacking(nodes)
@@ -51,7 +50,7 @@ export function renderInteractiveLayout(root: KNode): VNode {
 export function renderConstraints(node: KNode): VNode {
     let result = <g></g>
     const algorithm = (node.parent as KNode).properties.algorithm
-    if (isUndefined(algorithm) || algorithm.endsWith('layered')) {
+    if (algorithm === undefined || algorithm.endsWith('layered')) {
         result = renderLayeredConstraint(node)
     } else if (algorithm.endsWith( 'rectpacking')) {
         if (node.properties.desiredPosition !== -1) {

--- a/packages/klighd-interactive/src/klighd-interactive-mouselistener.ts
+++ b/packages/klighd-interactive/src/klighd-interactive-mouselistener.ts
@@ -3,7 +3,7 @@
  *
  * http://rtsys.informatik.uni-kiel.de/kieler
  *
- * Copyright 2019, 2020 by
+ * Copyright 2019-2021 by
  * + Kiel University
  *   + Department of Computer Science
  *     + Real-Time and Embedded Systems Group
@@ -16,8 +16,8 @@
  */
 
 import { injectable } from 'inversify';
-import { Action, MoveMouseListener, SEdge, SLabel, SModelElement, SNode } from 'sprotty';
-import { isUndefined } from 'util';
+import { MoveMouseListener, SEdge, SLabel, SModelElement, SNode } from 'sprotty';
+import { Action } from "sprotty-protocol"
 import { RefreshDiagramAction } from './actions';
 import { KNode } from './constraint-classes';
 import { filterKNodes } from './helper-methods';
@@ -88,7 +88,7 @@ export class KlighdInteractiveMouseListener extends MoveMouseListener {
 
                 const algorithm = ((targetNode as KNode).parent as KNode).properties.algorithm
                 // Set algorithm specific data
-                if (isUndefined(algorithm) || algorithm.endsWith('layered')) {
+                if (algorithm === undefined || algorithm.endsWith('layered')) {
                     this.data.set('layered', getLayers(this.nodes, this.target.direction))
                 } else if (algorithm.endsWith('rectpacking')) {
                     // Do nothing
@@ -100,12 +100,12 @@ export class KlighdInteractiveMouseListener extends MoveMouseListener {
                 this.target.shadowY = this.target.position.y
                 this.target.shadow = true
                 if (event.altKey) {
-                    if (isUndefined(algorithm) || algorithm.endsWith('layered')) {
-                        return [new DeleteStaticConstraintAction({
+                    if (algorithm === undefined || algorithm.endsWith('layered')) {
+                        return [DeleteStaticConstraintAction.create({
                             id: this.target.id
                         })]
                     } else if (algorithm.endsWith('rectpacking')) {
-                        return [new RectPackDeletePositionConstraintAction({
+                        return [RectPackDeletePositionConstraintAction.create({
                             id: this.target.id
                         })]
                     }
@@ -131,7 +131,7 @@ export class KlighdInteractiveMouseListener extends MoveMouseListener {
             this.target.shadow = false
             let result = super.mouseUp(this.target, event)
             const algorithm = (this.target.parent as KNode).properties.algorithm
-            if (isUndefined(algorithm) || algorithm.endsWith('layered')) {
+            if (algorithm === undefined || algorithm.endsWith('layered')) {
                 result = [setProperty(this.nodes, this.data.get('layered'), this.target)].concat(super.mouseUp(this.target, event));
             } else if (algorithm.endsWith('rectpacking')) {
                 const parent = this.nodes[0] ? this.nodes[0].parent as KNode : undefined
@@ -147,11 +147,11 @@ export class KlighdInteractiveMouseListener extends MoveMouseListener {
             if (result.some(action => action.kind === RefreshDiagramAction.KIND)) {
                 return result
             } else {
-                return result.concat([new RefreshDiagramAction()])
+                return result.concat([RefreshDiagramAction.create()])
             }
         } else if (this.target) {
             this.target.selected = false
-            const result = super.mouseUp(this.target, event).concat([new RefreshDiagramAction()]);
+            const result = super.mouseUp(this.target, event).concat([RefreshDiagramAction.create()]);
             this.target = undefined
             return result
         }

--- a/packages/klighd-interactive/src/layered/actions.ts
+++ b/packages/klighd-interactive/src/layered/actions.ts
@@ -15,7 +15,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-import { Action } from 'sprotty/lib';
+import { Action } from 'sprotty';
 import { DeleteConstraint, LayerConstraint, PositionConstraint, StaticConstraint } from './constraint-types';
 
 /**

--- a/packages/klighd-interactive/src/layered/actions.ts
+++ b/packages/klighd-interactive/src/layered/actions.ts
@@ -3,7 +3,7 @@
  *
  * http://rtsys.informatik.uni-kiel.de/kieler
  *
- * Copyright 2019 by
+ * Copyright 2019-2021 by
  * + Kiel University
  *   + Department of Computer Science
  *     + Real-Time and Embedded Systems Group
@@ -15,28 +15,44 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-import { Action } from 'sprotty';
+import { Action } from 'sprotty-protocol';
 import { DeleteConstraint, LayerConstraint, PositionConstraint, StaticConstraint } from './constraint-types';
 
 /**
  * Sent from client to server to set a position and layer constraint.
  */
-export class SetStaticConstraintAction implements Action {
-    static readonly KIND: string = 'setStaticConstraint'
-    readonly kind = SetStaticConstraintAction.KIND
+export interface SetStaticConstraintAction extends Action {
+    kind: typeof SetStaticConstraintAction.KIND
+    constraint: StaticConstraint
+}
 
-    constructor(public readonly constraint: StaticConstraint) {
+export namespace SetStaticConstraintAction {
+    export const KIND = 'setStaticConstraint'
+
+    export function create(constraint: StaticConstraint): SetStaticConstraintAction {
+        return {
+            kind: KIND,
+            constraint,
+        }
     }
 }
 
 /**
  * Sent from client to server to delete position and layer constraint on a node.
  */
-export class DeleteStaticConstraintAction implements Action {
-    static readonly KIND: string = 'deleteStaticConstraint'
-    readonly kind = DeleteStaticConstraintAction.KIND
+export interface DeleteStaticConstraintAction extends Action {
+    kind: typeof DeleteStaticConstraintAction.KIND
+    constraint: DeleteConstraint
+}
 
-    constructor(public readonly constraint: DeleteConstraint) {
+export namespace DeleteStaticConstraintAction {
+    export const KIND = 'deleteStaticConstraint'
+
+    export function create(constraint: DeleteConstraint): DeleteStaticConstraintAction {
+        return {
+            kind: KIND,
+            constraint,
+        }
     }
 }
 
@@ -44,11 +60,19 @@ export class DeleteStaticConstraintAction implements Action {
  * Sent from client to server to delete position constraint on a node.
  * Currently unused.
  */
-export class DeletePositionConstraintAction implements Action {
-    static readonly KIND: string = 'deletePositionConstraint'
-    readonly kind = DeletePositionConstraintAction.KIND
+export interface DeletePositionConstraintAction extends Action {
+    kind: typeof DeletePositionConstraintAction.KIND
+    constraint: DeleteConstraint
+}
 
-    constructor(public readonly constraint: DeleteConstraint) {
+export namespace DeletePositionConstraintAction {
+    export const KIND = 'deletePositionConstraint'
+
+    export function create(constraint: DeleteConstraint): DeletePositionConstraintAction {
+        return {
+            kind: KIND,
+            constraint,
+        }
     }
 }
 
@@ -56,32 +80,56 @@ export class DeletePositionConstraintAction implements Action {
  * Sent from client to server to delete layer constraint on a node.
  * Currently unused.
  */
-export class DeleteLayerConstraintAction implements Action {
-    static readonly KIND: string = 'deleteLayerConstraint'
-    readonly kind = DeleteLayerConstraintAction.KIND
+export interface DeleteLayerConstraintAction extends Action {
+    kind: typeof DeleteLayerConstraintAction.KIND
+    constraint: DeleteConstraint
+}
 
-    constructor(public readonly constraint: DeleteConstraint) {
+export namespace DeleteLayerConstraintAction {
+    export const KIND = 'deleteLayerConstraint'
+
+    export function create(constraint: DeleteConstraint): DeleteLayerConstraintAction {
+        return {
+            kind: KIND,
+            constraint,
+        }
     }
 }
 
 /**
  * Sent from client to server to set a layer constraint on a node.
  */
-export class SetLayerConstraintAction implements Action {
-    static readonly KIND: string = 'setLayerConstraint'
-    readonly kind = SetLayerConstraintAction.KIND
+export interface SetLayerConstraintAction extends Action {
+    kind: typeof SetLayerConstraintAction.KIND
+    constraint: LayerConstraint
+}
 
-    constructor(public readonly constraint: LayerConstraint) {
+export namespace SetLayerConstraintAction {
+    export const KIND = 'setLayerConstraint'
+
+    export function create(constraint: LayerConstraint): SetLayerConstraintAction {
+        return {
+            kind: KIND,
+            constraint,
+        }
     }
 }
 
 /**
  * Sent from client to server to set a position constraint on a node.
  */
-export class SetPositionConstraintAction implements Action {
-    static readonly KIND: string = 'setPositionConstraint'
-    readonly kind = SetPositionConstraintAction.KIND
+export interface SetPositionConstraintAction extends Action {
+    kind: typeof SetPositionConstraintAction.KIND
+    constraint: PositionConstraint
+}
 
-    constructor(public readonly constraint: PositionConstraint) {
+export namespace SetPositionConstraintAction {
+    export const KIND = 'setPositionConstraint'
+
+    export function create(constraint: PositionConstraint): SetPositionConstraintAction {
+        return {
+            kind: KIND,
+            constraint,
+        }
     }
 }

--- a/packages/klighd-interactive/src/layered/constraint-utils.ts
+++ b/packages/klighd-interactive/src/layered/constraint-utils.ts
@@ -3,7 +3,7 @@
  *
  * http://rtsys.informatik.uni-kiel.de/kieler
  *
- * Copyright 2019, 2020 by
+ * Copyright 2019-2021 by
  * + Kiel University
  *   + Department of Computer Science
  *     + Real-Time and Embedded Systems Group
@@ -15,7 +15,8 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-import { Action, SModelElement } from 'sprotty';
+import { SModelElement } from 'sprotty';
+import { Action } from 'sprotty-protocol';
 import { RefreshDiagramAction } from '../actions';
 import { Direction, KEdge, KNode } from '../constraint-classes';
 import { SetLayerConstraintAction, SetPositionConstraintAction, SetStaticConstraintAction } from './actions';
@@ -367,19 +368,19 @@ export function setProperty(nodes: KNode[], layers: Layer[], target: SModelEleme
 
     if (forbidden) {
         // If layer is forbidden just refresh
-        return new RefreshDiagramAction()
+        return RefreshDiagramAction.create()
     } else if (targetNode.properties.layerId !== layerOfTarget) {
         // layer constraint should only be set if the layer index changed
         if (shouldOnlyLCBeSet(targetNode, layers, direction)) {
             // only the layer constraint should be set
-            return new SetLayerConstraintAction({
+            return SetLayerConstraintAction.create({
                 id: targetNode.id,
                 layer: layerOfTarget,
                 layerCons: newLayerCons
             })
         } else {
             // If layer and position constraint should be set - send them both in one StaticConstraint
-            return new SetStaticConstraintAction({
+            return SetStaticConstraintAction.create({
                 id: targetNode.id,
                 layer: layerOfTarget,
                 layerCons: newLayerCons,
@@ -392,7 +393,7 @@ export function setProperty(nodes: KNode[], layers: Layer[], target: SModelEleme
         // position constraint should only be set if the position of the node changed
         if (targetNode.properties.positionId !== positionOfTarget) {
             // set the position Constraint
-            return new SetPositionConstraintAction({
+            return SetPositionConstraintAction.create({
                 id: targetNode.id,
                 position: positionOfTarget,
                 posCons: newPositionCons
@@ -400,5 +401,5 @@ export function setProperty(nodes: KNode[], layers: Layer[], target: SModelEleme
         }
     }
     // If the node was moved without setting a constraint - let it snap back
-    return new RefreshDiagramAction()
+    return RefreshDiagramAction.create()
 }

--- a/packages/klighd-interactive/src/layered/layered-interactive-view.tsx
+++ b/packages/klighd-interactive/src/layered/layered-interactive-view.tsx
@@ -15,8 +15,8 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 /** @jsx svg */
-import { svg } from 'snabbdom-jsx'; // eslint-disable-line @typescript-eslint/no-unused-vars
-import { VNode } from "snabbdom/vnode";
+import { VNode } from "snabbdom";
+import { svg } from 'sprotty'; // eslint-disable-line @typescript-eslint/no-unused-vars
 import { Direction, KNode } from '../constraint-classes';
 import { getSelectedNode } from '../helper-methods';
 import { createRect, createVerticalLine, renderArrow, renderCircle, renderLock } from '../interactive-view-objects';

--- a/packages/klighd-interactive/src/rect-packing/actions.ts
+++ b/packages/klighd-interactive/src/rect-packing/actions.ts
@@ -3,7 +3,7 @@
  *
  * http://rtsys.informatik.uni-kiel.de/kieler
  *
- * Copyright 2020 by
+ * Copyright 2020-2021 by
  * + Kiel University
  *   + Department of Computer Science
  *     + Real-Time and Embedded Systems Group
@@ -15,38 +15,62 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-import { Action } from 'sprotty';
+import { Action } from 'sprotty-protocol';
 import { AspectRatio, RectPackDeletePositionConstraint, RectPackSetPositionConstraint } from './constraint-types';
 
 /**
  * Send from client to server to set the aspect ratio.
  */
-export class SetAspectRatioAction implements Action {
-    static readonly KIND: string = 'setAspectRatio'
-    readonly kind = SetAspectRatioAction.KIND
+export interface SetAspectRatioAction extends Action {
+    kind: typeof SetAspectRatioAction.KIND
+    constraint: AspectRatio
+}
 
-    constructor(public readonly constraint: AspectRatio) {
+export namespace SetAspectRatioAction {
+    export const KIND = 'setAspectRatio'
+
+    export function create(constraint: AspectRatio): SetAspectRatioAction {
+        return {
+            kind: KIND,
+            constraint,
+        }
     }
 }
 
 /**
  * Send from client to server to delete an position constraint on a node.
  */
-export class RectPackDeletePositionConstraintAction implements Action {
-    static readonly KIND: string = 'rectPackDeletePositionConstraint'
-    readonly kind = RectPackDeletePositionConstraintAction.KIND
+export interface RectPackDeletePositionConstraintAction extends Action {
+    kind: typeof RectPackDeletePositionConstraintAction.KIND
+    constraint: RectPackDeletePositionConstraint
+}
 
-    constructor(public readonly constraint: RectPackDeletePositionConstraint) {
+export namespace RectPackDeletePositionConstraintAction {
+    export const KIND = 'rectPackDeletePositionConstraint'
+
+    export function create(constraint: RectPackDeletePositionConstraint): RectPackDeletePositionConstraintAction {
+        return {
+            kind: KIND,
+            constraint,
+        }
     }
 }
 
 /**
  * Send from client to server to set a position to force a node on a specific position.
  */
-export class RectPackSetPositionConstraintAction implements Action {
-    static readonly KIND: string = 'rectPackSetPositionConstraint'
-    readonly kind = RectPackSetPositionConstraintAction.KIND
+export interface RectPackSetPositionConstraintAction extends Action {
+    kind: typeof RectPackSetPositionConstraintAction.KIND
+    constraint: RectPackSetPositionConstraint
+}
 
-    constructor(public readonly constraint: RectPackSetPositionConstraint) {
+export namespace RectPackSetPositionConstraintAction {
+    export const KIND = 'rectPackSetPositionConstraint'
+
+    export function create(constraint: RectPackSetPositionConstraint): RectPackSetPositionConstraintAction {
+        return {
+            kind: KIND,
+            constraint,
+        }
     }
 }

--- a/packages/klighd-interactive/src/rect-packing/actions.ts
+++ b/packages/klighd-interactive/src/rect-packing/actions.ts
@@ -15,9 +15,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-import {
-    Action
-} from 'sprotty/lib';
+import { Action } from 'sprotty';
 import { AspectRatio, RectPackDeletePositionConstraint, RectPackSetPositionConstraint } from './constraint-types';
 
 /**

--- a/packages/klighd-interactive/src/rect-packing/constraint-util.ts
+++ b/packages/klighd-interactive/src/rect-packing/constraint-util.ts
@@ -3,7 +3,7 @@
  *
  * http://rtsys.informatik.uni-kiel.de/kieler
  *
- * Copyright 2020 by
+ * Copyright 2020-2021 by
  * + Kiel University
  *   + Department of Computer Science
  *     + Real-Time and Embedded Systems Group
@@ -15,7 +15,8 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-import { getAbsoluteBounds, translate } from 'sprotty';
+import { getAbsoluteBounds } from 'sprotty';
+import { Action, Bounds } from 'sprotty-protocol';
 import { RectPackSetPositionConstraintAction, SetAspectRatioAction } from './actions';
 import { RefreshDiagramAction } from '../actions';
 import { KNode } from '../constraint-classes';
@@ -27,15 +28,15 @@ import { KNode } from '../constraint-classes';
  * @param parent The parent node.
  * @param event The mouse released event.
  */
-export function setGenerateRectPackAction(nodes: KNode[], target: KNode, parent: KNode | undefined, event: MouseEvent): SetAspectRatioAction | RefreshDiagramAction {
+export function setGenerateRectPackAction(nodes: KNode[], target: KNode, parent: KNode | undefined, event: MouseEvent): Action {
     // If node is not put to a valid position the diagram will be refreshed.
-    let result = new RefreshDiagramAction()
+    let result: Action = RefreshDiagramAction.create()
     // If the node is moved on top of another node it takes its place.
     nodes.forEach(node => {
         if (node.id !== target.id) {
             const targetBounds = getAbsoluteBounds(node)
             const canvasBounds = target.root.canvasBounds;
-            const boundsInWindow = translate(targetBounds, canvasBounds);
+            const boundsInWindow = Bounds.translate(targetBounds, canvasBounds);
             const lowX = boundsInWindow.x
             const lowY = boundsInWindow.y
             const highX = boundsInWindow.x + boundsInWindow.width
@@ -51,14 +52,14 @@ export function setGenerateRectPackAction(nodes: KNode[], target: KNode, parent:
                         actualTargetPosition = target.properties.desiredPosition
                     }
                     if (actualPosition !== actualTargetPosition && actualPosition !== -1) {
-                        result = new RectPackSetPositionConstraintAction(
-                            {id: target.id, order: actualPosition}
-                        )
+                        result = RectPackSetPositionConstraintAction.create({
+                            id: target.id, order: actualPosition
+                        })
                     }
                 }
         }
     });
-    if (result instanceof RefreshDiagramAction) {
+    if (result.kind ===  RefreshDiagramAction.KIND) {
         // Case node should not be swapped.
 
         // Calculate aspect ratio.
@@ -84,7 +85,7 @@ export function setGenerateRectPackAction(nodes: KNode[], target: KNode, parent:
 
         // If changed update aspect ratio.
         if (parent && parent.properties.aspectRatio !== aspectRatio) {
-            return new SetAspectRatioAction({
+            return SetAspectRatioAction.create({
                 id: parent.id,
                 aspectRatio: aspectRatio
             })

--- a/packages/klighd-interactive/src/rect-packing/rect-packing-interactive-view.tsx
+++ b/packages/klighd-interactive/src/rect-packing/rect-packing-interactive-view.tsx
@@ -15,8 +15,8 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 /** @jsx svg */
-import { svg } from 'snabbdom-jsx'; // eslint-disable-line @typescript-eslint/no-unused-vars
-import { VNode } from "snabbdom/vnode";
+import { VNode } from "snabbdom";
+import { svg } from 'sprotty'; // eslint-disable-line @typescript-eslint/no-unused-vars
 import { KNode } from '../constraint-classes';
 import { renderLock } from '../interactive-view-objects';
 
@@ -58,7 +58,7 @@ export function renderHierarchyLevel(nodes: KNode[]): VNode {
         stroke={color}
         fill= 'rgba(0,0,0,0)'
         strokeWidth={2 * boundingBoxMargin}
-        style={{ 'stroke-dasharray': 4 }}>
+        style={{ 'stroke-dasharray': '4' }}>
     </rect></g>
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -980,11 +980,6 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.15.tgz#10ee6a6a3f971966fddfa3f6e89ef7a73ec622df"
   integrity sha512-F6S4Chv4JicJmyrwlDkxUdGNSplsQdGwp1A0AJloEVDirWdZOAiRHhovDlsFkKUrquUXhz1imJhXHsf59auyAg==
 
-"@types/node@^8.0.0":
-  version "8.10.66"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.66.tgz#dd035d409df322acc83dff62a602f12a5783bbb3"
-  integrity sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw==
-
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
@@ -1011,11 +1006,6 @@
   integrity sha512-EGkrJD5Uy+Pg0NUR8uA4bJ5WMfljyad0G+784vLCNUkD+QwOJXUbBYExXfVGf7YtyzdQp3L/XMYcliB987kL5Q==
   dependencies:
     source-map "^0.6.1"
-
-"@types/vscode@1.46.0":
-  version "1.46.0"
-  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.46.0.tgz#53f2075986e901ed25cd1ec5f3ffa5db84a111b3"
-  integrity sha512-8m9wPEB2mcRqTWNKs9A9Eqs8DrQZt0qNFO8GkxBOnyW6xR//3s77SoMgb/nY1ctzACsZXwZj3YRTDsn4bAoaUw==
 
 "@types/vscode@^1.56.0":
   version "1.57.0"
@@ -1618,10 +1608,10 @@ atomic-sleep@^1.0.0:
   resolved "https://registry.yarnpkg.com/atomic-sleep/-/atomic-sleep-1.0.0.tgz#eb85b77a601fc932cfe432c5acd364a9e2c9075b"
   integrity sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==
 
-autocompleter@5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/autocompleter/-/autocompleter-5.1.0.tgz#da80488ddf1f1d89b0a8f5d36cab24439de18ab8"
-  integrity sha512-xFZla6guwywqFJutoi5xrhAmaKw4/TU8CcLuNep/3OtiUfpNXtgzuBkkXJ6ysJIfG6MEEXFtUBg3PREN6HUVyw==
+autocompleter@^5.1.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/autocompleter/-/autocompleter-5.2.0.tgz#9ed3df262614fd557bf4d5bf67ab13cdee008203"
+  integrity sha512-CMYgI+r7RGZFaT0SvXcyBn1hb/Ne6XbjXimWQPc16LcwZgUGFBHg/Pv8honrwkTZE4DbfrD/MzqlG+Bn2u+1ng==
 
 avvio@^7.1.2:
   version "7.2.2"
@@ -1873,11 +1863,6 @@ buffer@^5.5.0:
   dependencies:
     base64-js "^1.3.1"
     ieee754 "^1.1.13"
-
-builtin-modules@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
-  integrity sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=
 
 builtin-status-codes@^3.0.0:
   version "3.0.0"
@@ -2257,7 +2242,7 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.12.1, commander@^2.20.0:
+commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -2795,11 +2780,6 @@ dezalgo@^1.0.0:
   dependencies:
     asap "^2.0.0"
     wrappy "1"
-
-diff@^4.0.1:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
-  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 diffie-hellman@^5.0.0:
   version "5.0.3"
@@ -3481,10 +3461,10 @@ file-loader@6.2.0:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
 
-file-saver@2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/file-saver/-/file-saver-2.0.2.tgz#06d6e728a9ea2df2cce2f8d9e84dfcdc338ec17a"
-  integrity sha512-Wz3c3XQ5xroCxd1G8b7yL0Ehkf0TC9oYC6buPFkNnU9EnaPlifeAFCyCh+iewXTyFRcg0a6j3J7FmJsIhlhBdw==
+file-saver@^2.0.2:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/file-saver/-/file-saver-2.0.5.tgz#d61cfe2ce059f414d899e9dd6d4107ee25670c38"
+  integrity sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA==
 
 file-uri-to-path@1.0.0:
   version "1.0.0"
@@ -6900,7 +6880,7 @@ redent@^3.0.0:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
 
-reflect-metadata@^0.1.12, reflect-metadata@^0.1.13:
+reflect-metadata@^0.1.13:
   version "0.1.13"
   resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.1.13.tgz#67ae3ca57c972a2aa1642b10fe363fe32d49dc08"
   integrity sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==
@@ -7014,7 +6994,7 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.1.6, resolve@^1.10.0, resolve@^1.20.0, resolve@^1.3.2, resolve@^1.9.0:
+resolve@^1.1.6, resolve@^1.10.0, resolve@^1.20.0, resolve@^1.9.0:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
   integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
@@ -7062,7 +7042,7 @@ rimraf@^2.5.4, rimraf@^2.6.3:
   dependencies:
     glob "^7.1.3"
 
-rimraf@^3.0.0, rimraf@^3.0.2, rimraf@latest:
+rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
@@ -7160,7 +7140,7 @@ semver-store@^0.3.0:
   resolved "https://registry.yarnpkg.com/semver-store/-/semver-store-0.3.0.tgz#ce602ff07df37080ec9f4fb40b29576547befbe9"
   integrity sha512-TcZvGMMy9vodEFSse30lWinkj+JgOBvPn8wRItpQRSayhc+4ssDs335uklkfvQQJgL/WvmHLVj4Ycv2s7QCQMg==
 
-"semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.6.0, semver@^5.7.1:
+"semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.4.1, semver@^5.5.0, semver@^5.6.0, semver@^5.7.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -7518,16 +7498,49 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-sprotty@0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/sprotty/-/sprotty-0.10.0.tgz#1c1d4fbce76127945d3bf5fb1e0f4995731a1271"
-  integrity sha512-Aicu0PEYulIFcI+FcFIydvwZu67+R0DqL60ZDIhkbre344uIlijwtOSoEyAwaihtODZAb4M9mFcrHb8qweRRwA==
+sprotty-protocol@~0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/sprotty-protocol/-/sprotty-protocol-0.11.0.tgz#f8ff89121155520b4e32ea0c05927e7a56173b99"
+  integrity sha512-OxRKrKx8mNOxX8CBKsP4epu7YGjT4XvaGwNfAwtVQVh2OPQq98t78A86XGjJThw9axm950QX0KQWGbrzX7FJuQ==
+
+sprotty-vscode-protocol@~0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/sprotty-vscode-protocol/-/sprotty-vscode-protocol-0.2.0.tgz#b9ee32fa4c2c19f6c08b6db3add3f3f2452b38e5"
+  integrity sha512-iF8Gs4xpyCwuEHU0IUgD/+ZAhf8/SpYht5oWbnhLqJtGHirck2pwcfERukcSKSsPVt1rVyABHJYws8i+Dn/fsA==
+  dependencies:
+    path "^0.12.7"
+    sprotty-protocol "~0.11.0"
+    vscode-languageserver-protocol "^3.16.0"
+
+sprotty-vscode-webview@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/sprotty-vscode-webview/-/sprotty-vscode-webview-0.2.0.tgz#da36ce5edcdaa9b8c45232cbf279152e6df8e852"
+  integrity sha512-koeoSZt4sFHymJr2rEU1IMuTfCConsjccru0FsuNr4ETXs/Tl7fw/7m7JIOd/xrUuLvUexbYXrihtCkQYGDJ1Q==
+  dependencies:
+    sprotty "~0.11.1"
+    sprotty-vscode-protocol "~0.2.0"
+    vscode-uri "^3.0.2"
+
+sprotty-vscode@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/sprotty-vscode/-/sprotty-vscode-0.2.0.tgz#8989bbdb817da2e8bef8a05e6a56fc033745889e"
+  integrity sha512-E84bAZ76pfm7NYFwZRxNvDFFCft8Iru5USDkdXwPUFqw7/oxWf9EHMShlswtuVG10Qf3C9Th8zojyrgK4i+Vcg==
+  dependencies:
+    path "^0.12.7"
+    sprotty-vscode-protocol "~0.2.0"
+    vscode-languageclient "^7.0.0"
+
+sprotty@0.11.1, sprotty@~0.11.1:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/sprotty/-/sprotty-0.11.1.tgz#3a04703cf10efe8bd89f02ecd6bb33637d9312c5"
+  integrity sha512-wHeDbhZeGPgZebJqoWpqrkQQlpfJ1uiXIjLgIIJOhY8+bkTkGClQDMget7H6Zun7yU56x/XtwgesDyMXA4BVFg==
   dependencies:
     "@vscode/codicons" "^0.0.25"
-    autocompleter "5.1.0"
-    file-saver "2.0.2"
+    autocompleter "^5.1.0"
+    file-saver "^2.0.2"
     inversify "^5.0.1"
     snabbdom "^3.0.3"
+    sprotty-protocol "~0.11.0"
     tinyqueue "^2.0.3"
 
 sshpk@^1.7.0:
@@ -8052,7 +8065,7 @@ tslib@2.1.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
   integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
 
-tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0:
+tslib@^1.8.1, tslib@^1.9.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
@@ -8061,32 +8074,6 @@ tslib@^2.0.3, tslib@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
   integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
-
-tslint@^5.11.0:
-  version "5.20.1"
-  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.20.1.tgz#e401e8aeda0152bc44dd07e614034f3f80c67b7d"
-  integrity sha512-EcMxhzCFt8k+/UP5r8waCf/lzmeSyVlqxqMEDQE7rWYiQky8KpIBz1JAoYXfROHrPZ1XXd43q8yQnULOLiBRQg==
-  dependencies:
-    "@babel/code-frame" "^7.0.0"
-    builtin-modules "^1.1.1"
-    chalk "^2.3.0"
-    commander "^2.12.1"
-    diff "^4.0.1"
-    glob "^7.1.1"
-    js-yaml "^3.13.1"
-    minimatch "^3.0.4"
-    mkdirp "^0.5.1"
-    resolve "^1.3.2"
-    semver "^5.3.0"
-    tslib "^1.8.0"
-    tsutils "^2.29.0"
-
-tsutils@^2.29.0:
-  version "2.29.0"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.29.0.tgz#32b488501467acbedd4b85498673a0812aca0b99"
-  integrity sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==
-  dependencies:
-    tslib "^1.8.1"
 
 tsutils@^3.21.0:
   version "3.21.0"
@@ -8181,16 +8168,6 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
-
-typescript@3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
-
-typescript@^3.1.3:
-  version "3.9.10"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
-  integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
 
 typescript@^4.3.0:
   version "4.4.4"
@@ -8461,33 +8438,21 @@ vscode-jsonrpc@6.0.0:
   resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz#108bdb09b4400705176b957ceca9e0880e9b6d4e"
   integrity sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==
 
-vscode-jsonrpc@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-4.0.0.tgz#a7bf74ef3254d0a0c272fab15c82128e378b3be9"
-  integrity sha512-perEnXQdQOJMTDFNv+UF3h1Y0z4iSiaN9jIlb0OqIYgosPCZGYh/MCUlkFtV2668PL69lRDO32hmvL2yiidUYg==
-
 vscode-jsonrpc@^5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-5.0.1.tgz#9bab9c330d89f43fc8c1e8702b5c36e058a01794"
   integrity sha512-JvONPptw3GAQGXlVV2utDcHx0BiY34FupW/kI6mZ5x06ER5DdPG/tXWMVHjTNULF5uKPOUUD0SaXg5QaubJL0A==
 
-vscode-languageclient@^5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/vscode-languageclient/-/vscode-languageclient-5.2.1.tgz#7cfc83a294c409f58cfa2b910a8cfeaad0397193"
-  integrity sha512-7jrS/9WnV0ruqPamN1nE7qCxn0phkH5LjSgSp9h6qoJGoeAKzwKz/PF6M+iGA/aklx4GLZg1prddhEPQtuXI1Q==
+vscode-languageclient@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/vscode-languageclient/-/vscode-languageclient-7.0.0.tgz#b505c22c21ffcf96e167799757fca07a6bad0fb2"
+  integrity sha512-P9AXdAPlsCgslpP9pRxYPqkNYV7Xq8300/aZDpO35j1fJm/ncize8iGswzYlcvFw5DQUx4eVk+KvfXdL0rehNg==
   dependencies:
-    semver "^5.5.0"
-    vscode-languageserver-protocol "3.14.1"
+    minimatch "^3.0.4"
+    semver "^7.3.4"
+    vscode-languageserver-protocol "3.16.0"
 
-vscode-languageserver-protocol@3.14.1:
-  version "3.14.1"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.14.1.tgz#b8aab6afae2849c84a8983d39a1cf742417afe2f"
-  integrity sha512-IL66BLb2g20uIKog5Y2dQ0IiigW0XKrvmWiOvc0yXw80z3tMEzEnHjaGAb3ENuU7MnQqgnYJ1Cl2l9RvNgDi4g==
-  dependencies:
-    vscode-jsonrpc "^4.0.0"
-    vscode-languageserver-types "3.14.0"
-
-vscode-languageserver-protocol@^3.14.1, vscode-languageserver-protocol@^3.16.0:
+vscode-languageserver-protocol@3.16.0, vscode-languageserver-protocol@^3.16.0:
   version "3.16.0"
   resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz#34135b61a9091db972188a07d337406a3cdbe821"
   integrity sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==
@@ -8495,33 +8460,15 @@ vscode-languageserver-protocol@^3.14.1, vscode-languageserver-protocol@^3.16.0:
     vscode-jsonrpc "6.0.0"
     vscode-languageserver-types "3.16.0"
 
-vscode-languageserver-types@3.14.0:
-  version "3.14.0"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.14.0.tgz#d3b5952246d30e5241592b6dde8280e03942e743"
-  integrity sha512-lTmS6AlAlMHOvPQemVwo3CezxBp0sNB95KNPkqp3Nxd5VFEnuG1ByM0zlRWos0zjO3ZWtkvhal0COgiV1xIA4A==
-
 vscode-languageserver-types@3.16.0:
   version "3.16.0"
   resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz#ecf393fc121ec6974b2da3efb3155644c514e247"
   integrity sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA==
 
-vscode-languageserver@^5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver/-/vscode-languageserver-5.2.1.tgz#0d2feddd33f92aadf5da32450df498d52f6f14eb"
-  integrity sha512-GuayqdKZqAwwaCUjDvMTAVRPJOp/SLON3mJ07eGsx/Iq9HjRymhKWztX41rISqDKhHVVyFM+IywICyZDla6U3A==
-  dependencies:
-    vscode-languageserver-protocol "3.14.1"
-    vscode-uri "^1.0.6"
-
-vscode-uri@2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-2.1.1.tgz#5aa1803391b6ebdd17d047f51365cf62c38f6e90"
-  integrity sha512-eY9jmGoEnVf8VE8xr5znSah7Qt1P/xsCdErz+g8HYZtJ7bZqKH5E3d+6oVNm1AC/c6IHUDokbmVXKOi4qPAC9A==
-
-vscode-uri@^1.0.6:
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-1.0.8.tgz#9769aaececae4026fb6e22359cb38946580ded59"
-  integrity sha512-obtSWTlbJ+a+TFRYGaUumtVwb+InIUVI0Lu0VBUAPmj2cU5JutEXg3xUE0c2J5Tcy7h2DEKVJBFi+Y9ZSFzzPQ==
+vscode-uri@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-3.0.2.tgz#ecfd1d066cb8ef4c3a208decdbab9a8c23d055d0"
+  integrity sha512-jkjy6pjU1fxUvI51P+gCsxg1u2n8LSt0W6KrCNQceaziKzff74GoWmjVG46KieVzybO1sttPQmYfrwSHey7GUA==
 
 vscode-ws-jsonrpc@^0.2.0:
   version "0.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -980,6 +980,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.15.tgz#10ee6a6a3f971966fddfa3f6e89ef7a73ec622df"
   integrity sha512-F6S4Chv4JicJmyrwlDkxUdGNSplsQdGwp1A0AJloEVDirWdZOAiRHhovDlsFkKUrquUXhz1imJhXHsf59auyAg==
 
+"@types/node@^8.0.0":
+  version "8.10.66"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.66.tgz#dd035d409df322acc83dff62a602f12a5783bbb3"
+  integrity sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw==
+
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
@@ -1006,6 +1011,11 @@
   integrity sha512-EGkrJD5Uy+Pg0NUR8uA4bJ5WMfljyad0G+784vLCNUkD+QwOJXUbBYExXfVGf7YtyzdQp3L/XMYcliB987kL5Q==
   dependencies:
     source-map "^0.6.1"
+
+"@types/vscode@1.46.0":
+  version "1.46.0"
+  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.46.0.tgz#53f2075986e901ed25cd1ec5f3ffa5db84a111b3"
+  integrity sha512-8m9wPEB2mcRqTWNKs9A9Eqs8DrQZt0qNFO8GkxBOnyW6xR//3s77SoMgb/nY1ctzACsZXwZj3YRTDsn4bAoaUw==
 
 "@types/vscode@^1.56.0":
   version "1.57.0"
@@ -1109,6 +1119,11 @@
   dependencies:
     "@typescript-eslint/types" "4.27.0"
     eslint-visitor-keys "^2.0.0"
+
+"@vscode/codicons@^0.0.25":
+  version "0.0.25"
+  resolved "https://registry.yarnpkg.com/@vscode/codicons/-/codicons-0.0.25.tgz#4ebc3e2c9e707ac46aea0becceda79f7738c647c"
+  integrity sha512-uqPhTdADjwoCh5Ufbv0M6TZiiP2mqbfJVB4grhVx1k+YeP03LDMOHBWPsNwGKn4/0S5Mq9o1w1GeftvR031Gzg==
 
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
@@ -1859,6 +1874,11 @@ buffer@^5.5.0:
     base64-js "^1.3.1"
     ieee754 "^1.1.13"
 
+builtin-modules@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
+  integrity sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=
+
 builtin-status-codes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
@@ -1996,7 +2016,7 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
-chalk@2.4.2, chalk@^2.0.0, chalk@^2.4.1, chalk@^2.4.2:
+chalk@2.4.2, chalk@^2.0.0, chalk@^2.3.0, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -2237,7 +2257,7 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.20.0:
+commander@^2.12.1, commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -2775,6 +2795,11 @@ dezalgo@^1.0.0:
   dependencies:
     asap "^2.0.0"
     wrappy "1"
+
+diff@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
+  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 diffie-hellman@^5.0.0:
   version "5.0.3"
@@ -3448,6 +3473,14 @@ file-entry-cache@^6.0.1:
   dependencies:
     flat-cache "^3.0.4"
 
+file-loader@6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-6.2.0.tgz#baef7cf8e1840df325e4390b4484879480eebe4d"
+  integrity sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==
+  dependencies:
+    loader-utils "^2.0.0"
+    schema-utils "^3.0.0"
+
 file-saver@2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/file-saver/-/file-saver-2.0.2.tgz#06d6e728a9ea2df2cce2f8d9e84dfcdc338ec17a"
@@ -4014,13 +4047,6 @@ html-minifier-terser@^5.0.1:
     relateurl "^0.2.7"
     terser "^4.6.3"
 
-html-parse-stringify2@^2:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/html-parse-stringify2/-/html-parse-stringify2-2.0.1.tgz#dc5670b7292ca158b7bc916c9a6735ac8872834a"
-  integrity sha1-3FZwtyksoVi3vJFsmmc1rIhyg0o=
-  dependencies:
-    void-elements "^2.0.1"
-
 html-webpack-plugin@4:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-4.5.2.tgz#76fc83fa1a0f12dd5f7da0404a54e2699666bc12"
@@ -4268,10 +4294,10 @@ into-stream@^6.0.0:
     from2 "^2.3.0"
     p-is-promise "^3.0.0"
 
-inversify@5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/inversify/-/inversify-5.0.1.tgz#500d709b1434896ce5a0d58915c4a4210e34fb6e"
-  integrity sha512-Ieh06s48WnEYGcqHepdsJUIJUXpwH5o5vodAX+DK2JA/gjy4EbEcQZxw+uFfzysmKjiLXGYwNG3qDZsKVMcINQ==
+inversify@^5.0.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/inversify/-/inversify-5.1.1.tgz#6fbd668c591337404e005a1946bfe0d802c08730"
+  integrity sha512-j8grHGDzv1v+8T1sAQ+3boTCntFPfvxLCkNcxB1J8qA0lUN+fAlSyYd+RXKvaPRL4AGyPxViutBEJHNXOyUdFQ==
 
 ip@^1.1.5:
   version "1.1.5"
@@ -4868,7 +4894,7 @@ loader-runner@^2.4.0:
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
   integrity sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==
 
-loader-utils@^1.2.3:
+loader-utils@^1.0.2, loader-utils@^1.2.3:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.0.tgz#c579b5e34cb34b1a74edc6c1fb36bfa371d5a613"
   integrity sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==
@@ -6988,7 +7014,7 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.1.6, resolve@^1.10.0, resolve@^1.20.0, resolve@^1.9.0:
+resolve@^1.1.6, resolve@^1.10.0, resolve@^1.20.0, resolve@^1.3.2, resolve@^1.9.0:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
   integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
@@ -7036,7 +7062,7 @@ rimraf@^2.5.4, rimraf@^2.6.3:
   dependencies:
     glob "^7.1.3"
 
-rimraf@^3.0.0, rimraf@^3.0.2:
+rimraf@^3.0.0, rimraf@^3.0.2, rimraf@latest:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
@@ -7134,7 +7160,7 @@ semver-store@^0.3.0:
   resolved "https://registry.yarnpkg.com/semver-store/-/semver-store-0.3.0.tgz#ce602ff07df37080ec9f4fb40b29576547befbe9"
   integrity sha512-TcZvGMMy9vodEFSse30lWinkj+JgOBvPn8wRItpQRSayhc+4ssDs335uklkfvQQJgL/WvmHLVj4Ycv2s7QCQMg==
 
-"semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.4.1, semver@^5.5.0, semver@^5.6.0, semver@^5.7.1:
+"semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.6.0, semver@^5.7.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -7312,29 +7338,10 @@ smart-buffer@^4.1.0:
   resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.1.0.tgz#91605c25d91652f4661ea69ccf45f1b331ca21ba"
   integrity sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw==
 
-snabbdom-jsx@0.4.2:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/snabbdom-jsx/-/snabbdom-jsx-0.4.2.tgz#e580682d60b4cc1da9898c6a0bacfcd062a0cffc"
-  integrity sha512-6akqPyuossD3niO3RCgaqAIrQ6ylBI+shzUKukIwqkNOybCmgst81khJ48BHYtEamQ7ltlFaEKjvKi3N0NPNVw==
-  dependencies:
-    snabbdom "^0.7.0"
-
-snabbdom-virtualize@0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/snabbdom-virtualize/-/snabbdom-virtualize-0.7.0.tgz#31f683338b66457bded8c1e22cdd8ed438c2a387"
-  integrity sha1-MfaDM4tmRXve2MHiLN2O1DjCo4c=
-  dependencies:
-    html-parse-stringify2 "^2"
-
-snabbdom@0.7.3:
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/snabbdom/-/snabbdom-0.7.3.tgz#27b29b41228779ae5d99696a07edaaff4912fc54"
-  integrity sha512-XNh90GQiV36hWdfSL46fIVrSSvmBuZlWk3++qaEgBeQWQJCqTphcbjTODPv8/vyZHJaB3VhePsWfGxi/zBxXyw==
-
-snabbdom@^0.7.0:
-  version "0.7.4"
-  resolved "https://registry.yarnpkg.com/snabbdom/-/snabbdom-0.7.4.tgz#817f07e8d3fb870960c3763b8da56f1ba982d31a"
-  integrity sha512-nnN+7uZ2NTIiu7EPMNwSDhmrYXqwlfCP/j72RdzvDPujXyvQxOW7Jl9yuLayzxMHDNWQR7FM6Pcn4wnDpKRe6Q==
+snabbdom@^3.0.3:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/snabbdom/-/snabbdom-3.1.0.tgz#8ca931f562d3421de71c8b44e70c285cfa5f2dc9"
+  integrity sha512-mcmPJMMKbkkPDPeCQ5D7RzqMHlLUyjl+OxOGblsutkzDbuYijCQGBOWJInjnWZ85DtoHdElrDTjA9g85s2YQ5Q==
 
 snapdragon-node@^2.0.1:
   version "2.1.1"
@@ -7511,45 +7518,17 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-sprotty-vscode-protocol@^0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/sprotty-vscode-protocol/-/sprotty-vscode-protocol-0.0.5.tgz#6d0578d0094b224ea50549786ebd59dadace7fcf"
-  integrity sha512-nhuOLHgWEczQRjYgHE3C8oHv7cxGsv2mAacdETkMYnnBkLG3t28N68ydIt9a/lv6EhMJDwh9dLqyDBbvHPA3Wg==
+sprotty@0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/sprotty/-/sprotty-0.10.0.tgz#1c1d4fbce76127945d3bf5fb1e0f4995731a1271"
+  integrity sha512-Aicu0PEYulIFcI+FcFIydvwZu67+R0DqL60ZDIhkbre344uIlijwtOSoEyAwaihtODZAb4M9mFcrHb8qweRRwA==
   dependencies:
-    path "^0.12.7"
-    vscode-languageserver-protocol "^3.14.1"
-
-sprotty-vscode-webview@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/sprotty-vscode-webview/-/sprotty-vscode-webview-0.1.2.tgz#ecac70be52a7d631f269c6444f12f6586ea58f1d"
-  integrity sha512-1fEi/ipyWGiTvT1Nm7H9n0f8w1N4/ZJ9+cblM5qFSMPWLdAQOajZQfBFa4nF4/ll6voa2m+b0BDSRwUP/CJteg==
-  dependencies:
-    reflect-metadata "^0.1.12"
-    sprotty "0.9.0"
-    sprotty-vscode-protocol "^0.0.5"
-    vscode-uri "2.1.1"
-
-sprotty-vscode@^0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/sprotty-vscode/-/sprotty-vscode-0.1.3.tgz#15f9d719fc5a7b313d18343dde3d45ea47913b20"
-  integrity sha512-4NbchD6rqKKYGUenUwRGRmDIuJyepiM5epjirX08KMxw+PgWAuuR79RWjk/u3iXqiWtFkjFd+mU/hwH6PVUJ9Q==
-  dependencies:
-    path "^0.12.7"
-    sprotty-vscode-protocol "^0.0.5"
-    vscode-languageclient "^5.2.1"
-    vscode-languageserver "^5.2.1"
-
-sprotty@0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/sprotty/-/sprotty-0.9.0.tgz#5644cdb239c43e878705fe76d71ffc73f27cd27b"
-  integrity sha512-kPcXVgspNnMq/ysFFOVfjBkrNK/w9LXSiX1mx3mkEiEVbthjEiKicw+l9uwW9RJH+QvqrK8LrXqEZzKGERUQyA==
-  dependencies:
+    "@vscode/codicons" "^0.0.25"
     autocompleter "5.1.0"
     file-saver "2.0.2"
-    inversify "5.0.1"
-    snabbdom "0.7.3"
-    snabbdom-jsx "0.4.2"
-    snabbdom-virtualize "0.7.0"
+    inversify "^5.0.1"
+    snabbdom "^3.0.3"
+    tinyqueue "^2.0.3"
 
 sshpk@^1.7.0:
   version "1.16.1"
@@ -7950,6 +7929,11 @@ tiny-lru@^7.0.0:
   resolved "https://registry.yarnpkg.com/tiny-lru/-/tiny-lru-7.0.6.tgz#b0c3cdede1e5882aa2d1ae21cb2ceccf2a331f24"
   integrity sha512-zNYO0Kvgn5rXzWpL0y3RS09sMK67eGaQj9805jlK9G6pSadfriTczzLHFXa/xcW4mIRfmlB9HyQ/+SgL0V1uow==
 
+tinyqueue@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/tinyqueue/-/tinyqueue-2.0.3.tgz#64d8492ebf39e7801d7bd34062e29b45b2035f08"
+  integrity sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==
+
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
@@ -8041,7 +8025,7 @@ trim-off-newlines@^1.0.0:
   resolved "https://registry.yarnpkg.com/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz#9f9ba9d9efa8764c387698bcbfeb2c848f11adb3"
   integrity sha1-n5up2e+odkw4dpi8v+sshI8RrbM=
 
-ts-loader@^8.0.14, ts-loader@^8.2.0:
+ts-loader@^8.0.14:
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-8.3.0.tgz#83360496d6f8004fab35825279132c93412edf33"
   integrity sha512-MgGly4I6cStsJy27ViE32UoqxPTN9Xly4anxxVyaIWR+9BGxboV4EyJBGfR3RePV7Ksjj3rHmPZJeIt+7o4Vag==
@@ -8052,12 +8036,23 @@ ts-loader@^8.0.14, ts-loader@^8.2.0:
     micromatch "^4.0.0"
     semver "^7.3.4"
 
+ts-loader@^8.0.3:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-8.0.3.tgz#56858f4296edf1ed55e01f8520552984d3f0911c"
+  integrity sha512-wsqfnVdB7xQiqhqbz2ZPLGHLPZbHVV5Qn/MNFZkCFxRU1miDyxKORucDGxKtsQJ63Rfza0udiUxWF5nHY6bpdQ==
+  dependencies:
+    chalk "^2.3.0"
+    enhanced-resolve "^4.0.0"
+    loader-utils "^1.0.2"
+    micromatch "^4.0.0"
+    semver "^6.0.0"
+
 tslib@2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
   integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
 
-tslib@^1.8.1, tslib@^1.9.0:
+tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
@@ -8066,6 +8061,32 @@ tslib@^2.0.3, tslib@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
   integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
+
+tslint@^5.11.0:
+  version "5.20.1"
+  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.20.1.tgz#e401e8aeda0152bc44dd07e614034f3f80c67b7d"
+  integrity sha512-EcMxhzCFt8k+/UP5r8waCf/lzmeSyVlqxqMEDQE7rWYiQky8KpIBz1JAoYXfROHrPZ1XXd43q8yQnULOLiBRQg==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    builtin-modules "^1.1.1"
+    chalk "^2.3.0"
+    commander "^2.12.1"
+    diff "^4.0.1"
+    glob "^7.1.1"
+    js-yaml "^3.13.1"
+    minimatch "^3.0.4"
+    mkdirp "^0.5.1"
+    resolve "^1.3.2"
+    semver "^5.3.0"
+    tslib "^1.8.0"
+    tsutils "^2.29.0"
+
+tsutils@^2.29.0:
+  version "2.29.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.29.0.tgz#32b488501467acbedd4b85498673a0812aca0b99"
+  integrity sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==
+  dependencies:
+    tslib "^1.8.1"
 
 tsutils@^3.21.0:
   version "3.21.0"
@@ -8161,7 +8182,22 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.1.3, typescript@^4.3.2:
+typescript@3.8.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+
+typescript@^3.1.3:
+  version "3.9.10"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
+  integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
+
+typescript@^4.3.0:
+  version "4.4.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.4.tgz#2cd01a1a1f160704d3101fd5a58ff0f9fcb8030c"
+  integrity sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==
+
+typescript@^4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.2.tgz#399ab18aac45802d6f2498de5054fcbbe716a805"
   integrity sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==
@@ -8367,11 +8403,6 @@ vm-browserify@^1.0.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
-
-void-elements@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-2.0.1.tgz#c066afb582bb1cb4128d60ea92392e94d5e9dbec"
-  integrity sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=
 
 vsce@^1.95.1:
   version "1.95.1"


### PR DESCRIPTION
With this PR the project adapts to all changes of Sproty 0.10.0 and 0.11.0 and the new sprotty-vscode gluecode 0.2.0.

This also unifies the style of actions to the new style of actions in Sprotty 0.11. They changed actions to be interfaces only instead of classes to reflect many of them coming from some server where the natural `instanceof` check would not work.
Furthermore the interaction between feather-icons and snabbdom pointed to an issue with patching with this update, so this also addresses that by directly using snabbdom's VNodes to include the feather icons.