### PR TITLE
Added descriptions for synthesis options and show them in tooltips on hover.

### DIFF
--- a/packages/klighd-core/src/options/components/option-inputs.tsx
+++ b/packages/klighd-core/src/options/components/option-inputs.tsx
@@ -3,7 +3,7 @@
  *
  * http://rtsys.informatik.uni-kiel.de/kieler
  *
- * Copyright 2021 by
+ * Copyright 2021-2022 by
  * + Kiel University
  *   + Department of Computer Science
  *     + Real-Time and Embedded Systems Group
@@ -26,6 +26,7 @@ interface BaseProps<T> {
     id: string;
     name: string;
     value: T;
+    description?: string;
     onChange: OptionChangeHandler<T>;
 }
 
@@ -36,10 +37,11 @@ export function CheckOption(props: CheckOptionProps): VNode {
     // The sprotty jsx function always puts an additional 'props' key around the element, requiring this hack.
     props = (props as any as {props: CheckOptionProps}).props
     return (
-        <label htmlFor={props.id}>
+        <label htmlFor={props.id} title={props.description ?? props.name}>
             <input
                 class-options__input="true"
                 type="checkbox"
+                title={props.description ?? props.name}
                 id={props.id}
                 checked={props.value}
                 on-change={() => props.onChange(!props.value)}
@@ -62,10 +64,11 @@ export function ChoiceOption(props: ChoiceOptionProps): VNode {
         <div class-options__input-container="true">
             <legend>{props.name}</legend>
             {props.availableValues.map((value, i) => (
-                <label key={value} htmlFor={props.availableValuesLabels?.[i] ?? value}>
+                <label key={value} htmlFor={props.availableValuesLabels?.[i] ?? value} title={props.description ?? props.name}>
                     <input
                         class-options__input="true"
                         type="radio"
+                        title={props.description ?? props.name}
                         id={props.availableValuesLabels?.[i] ?? value}
                         checked={props.value === value}
                         on-change={() => props.onChange(value)}
@@ -89,12 +92,13 @@ export function RangeOption(props: RangeOptionProps): VNode {
     props = (props as any as {props: RangeOptionProps}).props
     return (
         <div class-options__column="true">
-            <label htmlFor={props.id}>
+            <label htmlFor={props.id} title={props.description ?? props.name}>
                 {props.name}: {props.value}
             </label>
             <input
                 class-options__input="true"
                 type="range"
+                title={props.description ?? props.name}
                 id={props.id}
                 min={props.minValue}
                 max={props.maxValue}
@@ -114,10 +118,11 @@ export function TextOption(props: TextOptionProps): VNode {
     props = (props as any as {props: TextOptionProps}).props
     return (
         <div class-options__column="true">
-            <label htmlFor={props.id}>{props.name}</label>
+            <label htmlFor={props.id} title={props.description ?? props.name}>{props.name}</label>
             <input
                 class-options__input options__text-field="true"
                 type="text"
+                title={props.description ?? props.name}
                 id={props.id}
                 value={props.value}
                 on-change={(e: any) => props.onChange(e.target.value)}
@@ -150,7 +155,9 @@ export function CategoryOption(props: CategoryOptionProps, children: VNode[]): V
 
     return (
         <details open={props.value} class-options__category="true" on-toggle={handleToggle}>
-            <summary>{props.name}</summary>
+            <summary title={props.description ?? props.name}>
+                {props.name}
+            </summary>
             {children}
         </details>
     );

--- a/packages/klighd-core/src/options/option-models.ts
+++ b/packages/klighd-core/src/options/option-models.ts
@@ -3,7 +3,7 @@
  *
  * http://rtsys.informatik.uni-kiel.de/kieler
  *
- * Copyright 2018, 2020 by
+ * Copyright 2018-2022 by
  * + Kiel University
  *   + Department of Computer Science
  *     + Real-Time and Embedded Systems Group
@@ -22,6 +22,7 @@ export interface RenderOption {
     type: TransformationOptionType;
     initialValue: any;
     currentValue: any;
+    description?: string;
 }
 
 export interface Preference extends RenderOption {

--- a/packages/klighd-core/src/options/options-renderer.tsx
+++ b/packages/klighd-core/src/options/options-renderer.tsx
@@ -3,7 +3,7 @@
  *
  * http://rtsys.informatik.uni-kiel.de/kieler
  *
- * Copyright 2021 by
+ * Copyright 2021-2022 by
  * + Kiel University
  *   + Department of Computer Science
  *     + Real-Time and Embedded Systems Group
@@ -131,6 +131,7 @@ export class OptionsRenderer {
                                 id={option.id}
                                 name={option.name}
                                 value={option.currentValue}
+                                description={option.description}
                                 onChange={this.handleSynthesisOptionChange.bind(this, option)}
                             />
                         );
@@ -142,6 +143,7 @@ export class OptionsRenderer {
                                 name={option.name}
                                 value={option.currentValue}
                                 availableValues={option.values}
+                                description={option.description}
                                 onChange={this.handleSynthesisOptionChange.bind(this, option)}
                             />
                         );
@@ -155,6 +157,7 @@ export class OptionsRenderer {
                                 minValue={(option as RangeOptionData).range.first}
                                 maxValue={(option as RangeOptionData).range.second}
                                 stepSize={(option as RangeOptionData).stepSize}
+                                description={option.description}
                                 onChange={this.handleSynthesisOptionChange.bind(this, option)}
                             />
                         );
@@ -165,6 +168,7 @@ export class OptionsRenderer {
                                 id={option.id}
                                 name={option.name}
                                 value={option.currentValue}
+                                description={option.description}
                                 onChange={this.handleSynthesisOptionChange.bind(this, option)}
                             />
                         );
@@ -177,6 +181,7 @@ export class OptionsRenderer {
                                 id={option.id}
                                 name={option.name}
                                 value={option.currentValue}
+                                description={option.description}
                                 onChange={this.handleSynthesisOptionChange.bind(this, option)}
                             >
                                 {/* Skip rendering the children if the category is closed */}
@@ -212,6 +217,7 @@ export class OptionsRenderer {
                             minValue={option.minValue}
                             maxValue={option.maxValue}
                             stepSize={option.type === Type.INT ? 1 : 0.01}
+                            description={option.description}
                             onChange={this.handleLayoutOptionChange.bind(this, option)}
                         />
                     );
@@ -222,6 +228,7 @@ export class OptionsRenderer {
                             id={option.optionId}
                             name={option.name}
                             value={option.currentValue}
+                            description={option.description}
                             onChange={this.handleLayoutOptionChange.bind(this, option)}
                         />
                     );
@@ -234,6 +241,7 @@ export class OptionsRenderer {
                             value={option.currentValue}
                             availableValues={option.availableValues.k}
                             availableValuesLabels={option.availableValues.v}
+                            description={option.description}
                             onChange={this.handleLayoutOptionChange.bind(this, option)}
                         />
                     );
@@ -263,6 +271,7 @@ export class OptionsRenderer {
                             id={option.id}
                             name={option.name}
                             value={option.currentValue}
+                            description={option.description}
                             onChange={this.handleRenderOptionChange.bind(this, option)}
                         />
                     );
@@ -276,6 +285,7 @@ export class OptionsRenderer {
                             minValue={(option as RangeOptionData).range.first}
                             maxValue={(option as RangeOptionData).range.second}
                             stepSize={(option as RangeOptionData).stepSize}
+                            description={option.description}
                             onChange={this.handleRenderOptionChange.bind(this, option)}
                         />
                     );


### PR DESCRIPTION
Just a small change to allow to have a more descriptive text shown when hovering over synthesis options. Follows the behavior of hover feedback for layout options.
If no description is set, the name of the option is shown as the tooltip instead.

Linked to Server change in [#108 in KLighD](https://github.com/kieler/KLighD/pull/108)

To be merged once new KLighD nightly build host is up again.