### PR TITLE
update properties to be accessed using <string,unknown> map

### DIFF
--- a/packages/klighd-core/src/hover/popup-provider.ts
+++ b/packages/klighd-core/src/hover/popup-provider.ts
@@ -67,12 +67,12 @@ export class PopupModelProvider implements IPopupModelProvider {
      * @param id The ID of the KRendering within that SKGraphElement.
      */
     protected findTooltip(element: SKGraphElement, id: string): string | undefined {
-        if (element.tooltip) {
-            return element.tooltip;
+        if (element.properties['klighd.tooltip'] as string) {
+            return element.properties['klighd.tooltip'] as string;
         }
         const rendering = findRendering(element, id);
         if (rendering) {
-            return rendering.tooltip;
+            return rendering.properties['klighd.tooltip'] as string;
         }
     }
 }

--- a/packages/klighd-core/src/options/options-blacklist.ts
+++ b/packages/klighd-core/src/options/options-blacklist.ts
@@ -50,8 +50,6 @@ export const optionsBlacklist = [
   'de.cau.cs.kieler.sccharts.ui.synthesis.hooks.ExpandCollapseHook.CHECK-1902441701',
   'de.cau.cs.kieler.sccharts.ui.synthesis.AdaptiveZoom.CHECK-1237943491',
   'de.cau.cs.kieler.sccharts.ui.synthesis.GeneralSynthesisOptions.CHECK-857562601',
-  'de.cau.cs.kieler.sccharts.ui.synthesis.hooks.LabelShorteningHook.CHOICE2065322287',
-  'de.cau.cs.kieler.sccharts.ui.synthesis.hooks.LabelShorteningHook.RANGE-230395005',
   'de.cau.cs.kieler.graphs.klighd.syntheses.KGraphDiagramSynthesis.CHECK-1675366116',
   'de.cau.cs.kieler.graphs.klighd.syntheses.AbstractStyledDiagramSynthesis.CHOICE577556810',
   'de.cau.cs.kieler.scg.klighd.SCGraphSynthesisOptions.CHECK-496527882',

--- a/packages/klighd-core/src/skgraph-models.ts
+++ b/packages/klighd-core/src/skgraph-models.ts
@@ -26,6 +26,7 @@ import { Bounds, boundsFeature, moveFeature, Point, popupFeature, RectangularPor
  */
 export interface SKGraphElement extends KGraphElement {
     tooltip?: string
+    properties: Record<string, unknown>
 }
 
 export const NODE_TYPE = 'node'
@@ -57,6 +58,7 @@ export class SKPort extends RectangularPort implements SKGraphElement {
     hasFeature(feature: symbol): boolean {
         return feature === selectFeature || feature === popupFeature
     }
+    properties: Record<string, unknown>
 }
 
 /**
@@ -73,6 +75,7 @@ export class SKLabel extends SLabel implements SKGraphElement {
         // estimated during the estimateTextBounds action.
         return feature === selectFeature || feature === boundsFeature || feature === popupFeature
     }
+    properties: Record<string, unknown>
 }
 
 /**
@@ -83,6 +86,7 @@ export class SKEdge extends KEdge {
     hasFeature(feature: symbol): boolean {
         return feature === selectFeature || feature === popupFeature
     }
+    properties: Record<string, unknown>
 }
 
 /**
@@ -102,6 +106,9 @@ export interface KRendering extends KGraphData, KStyleHolder {
     actions: KAction[]
     // not in the original java model, but is included in messages to remove the need to call '[Grid]?PlacementUtil.evaluate[Grid|Area|Point]Placement'
     // and similar methods on client side for every rendering
+
+    properties: Record<string, unknown>
+    // TODO: remove below fields
     /**
      * The server pre-calculated bounds for this rendering.
      */

--- a/packages/klighd-core/src/skgraph-models.ts
+++ b/packages/klighd-core/src/skgraph-models.ts
@@ -108,28 +108,6 @@ export interface KRendering extends KGraphData, KStyleHolder {
     // and similar methods on client side for every rendering
 
     properties: Record<string, unknown>
-    // TODO: remove below fields
-    /**
-     * The server pre-calculated bounds for this rendering.
-     */
-    calculatedBounds?: Bounds
-    /**
-     * The server pre-calculated decoration for this rendering.
-     */
-    calculatedDecoration?: Decoration
-    /**
-     * A possible tooltip that can be shown for this rendering.
-     */
-    tooltip?: string
-
-    /**
-     * Whether the server pre-determined this KRendering to be the title of a node or not. 
-     */
-    isNodeTitle?: boolean
-    /**
-     * The unique identifier of this rendering.
-     */
-    renderingId: string
 }
 
 /**

--- a/packages/klighd-core/src/skgraph-models.ts
+++ b/packages/klighd-core/src/skgraph-models.ts
@@ -40,7 +40,7 @@ export class SKNode extends KNode {
     tooltip?: string
     hasFeature(feature: symbol): boolean {
         return feature === selectFeature
-            || (feature === moveFeature && (this.parent as SKNode).properties && (this.parent as SKNode).properties.interactiveLayout)
+            || (feature === moveFeature && (this.parent as SKNode).properties && (this.parent as SKNode).properties.get("org.eclipse.elk.interactiveLayout") as boolean)
             || feature === popupFeature
     }
 }

--- a/packages/klighd-core/src/skgraph-models.ts
+++ b/packages/klighd-core/src/skgraph-models.ts
@@ -40,7 +40,7 @@ export class SKNode extends KNode {
     tooltip?: string
     hasFeature(feature: symbol): boolean {
         return feature === selectFeature
-            || (feature === moveFeature && (this.parent as SKNode).properties && (this.parent as SKNode).properties.get('org.eclipse.elk.interactiveLayout') as boolean)
+            || (feature === moveFeature && (this.parent as SKNode).properties && (this.parent as SKNode).properties['org.eclipse.elk.interactiveLayout'] as boolean)
             || feature === popupFeature
     }
 }

--- a/packages/klighd-core/src/skgraph-models.ts
+++ b/packages/klighd-core/src/skgraph-models.ts
@@ -40,7 +40,7 @@ export class SKNode extends KNode {
     tooltip?: string
     hasFeature(feature: symbol): boolean {
         return feature === selectFeature
-            || (feature === moveFeature && (this.parent as SKNode).properties && (this.parent as SKNode).properties.get("org.eclipse.elk.interactiveLayout") as boolean)
+            || (feature === moveFeature && (this.parent as SKNode).properties && (this.parent as SKNode).properties.get('org.eclipse.elk.interactiveLayout') as boolean)
             || feature === popupFeature
     }
 }

--- a/packages/klighd-core/src/skgraph-utils.ts
+++ b/packages/klighd-core/src/skgraph-utils.ts
@@ -62,12 +62,12 @@ export function findRendering(element: SKGraphElement, id: string): KRendering |
             if (isContainerRendering(currentElement)) {
                 // First, look for the ID in the child renderings.
                 nextElement = currentElement.children.find(childRendering => {
-                    return id.startsWith(childRendering.renderingId)
+                    return id.startsWith(childRendering.properties['klighd.lsp.rendering.id'] as string)
                 }) as KRendering
             }
             if (nextElement === undefined && currentElement.type === K_POLYLINE) {
                 // If the rendering was not found yet, take the junction point rendering.
-                if (id.startsWith((currentElement as KPolyline).junctionPointRendering.renderingId)) {
+                if (id.startsWith((currentElement as KPolyline).junctionPointRendering.properties['klighd.lsp.rendering.id'] as string)) {
                     nextElement = (currentElement as KPolyline).junctionPointRendering
                 }
             } if (nextElement === undefined) {
@@ -79,7 +79,7 @@ export function findRendering(element: SKGraphElement, id: string): KRendering |
         }
     }
     // Now the currentElement should be the element searched for by the id.
-    if (currentElement.renderingId !== id) {
+    if (currentElement.properties['klighd.lsp.rendering.id'] as string !== id) {
         console.error('The found element does not match the searched id! id: ' + id + ', found element: ' + currentElement)
         return
     }

--- a/packages/klighd-core/src/views-common.ts
+++ b/packages/klighd-core/src/views-common.ts
@@ -314,7 +314,7 @@ export function camelToKebab(string: string): string {
  */
 export function findBoundsAndTransformationData(rendering: KRendering, styles: KStyles, parent: SKGraphElement,
     context: SKGraphModelRenderer, isEdge?: boolean, boundingBox?: boolean): BoundsAndTransformation | undefined {
-    
+
     if (rendering.type === K_TEXT && !boundingBox) {
         return findTextBoundsAndTransformationData(rendering as KText, styles, parent, context)
     }
@@ -322,17 +322,17 @@ export function findBoundsAndTransformationData(rendering: KRendering, styles: K
     let bounds
     let decoration
 
-    if (rendering.calculatedBounds !== undefined) {
+    if (rendering.properties['klighd.lsp.calculated.bounds'] as Bounds !== undefined) {
         // Bounds are in the calculatedBounds of the rendering.
-        bounds = rendering.calculatedBounds
+        bounds = rendering.properties['klighd.lsp.calculated.bounds'] as Bounds
     }
     // If no bounds have been found yet, they should be in the boundsMap.
     if (bounds === undefined && context.boundsMap !== undefined) {
-        bounds = findById(context.boundsMap, rendering.renderingId)
+        bounds = findById(context.boundsMap, rendering.properties['klighd.lsp.rendering.id'] as string)
     }
     // If there is a decoration, calculate the bounds and decoration (containing a possible rotation) from that.
-    if (rendering.calculatedDecoration !== undefined) {
-        decoration = rendering.calculatedDecoration
+    if (rendering.properties['klighd.lsp.calculated.decoration'] as Decoration !== undefined) {
+        decoration = rendering.properties['klighd.lsp.calculated.decoration'] as Decoration
         bounds = {
             x: decoration.bounds.x + decoration.origin.x,
             y: decoration.bounds.y + decoration.origin.y,
@@ -342,7 +342,7 @@ export function findBoundsAndTransformationData(rendering: KRendering, styles: K
     }
     // Same as above, if the decoration has not been found yet, it should be in the decorationMap.
     if (decoration === undefined && context.decorationMap !== undefined) {
-        decoration = findById(context.decorationMap, rendering.renderingId)
+        decoration = findById(context.decorationMap, rendering.properties['klighd.lsp.rendering.id'] as string)
         if (decoration !== undefined) {
             bounds = {
                 x: decoration.bounds.x + decoration.origin.x,
@@ -417,12 +417,12 @@ export function findTextBoundsAndTransformationData(rendering: KText, styles: KS
     // The text split into an array for each individual line
     const lines = text?.split('\n')?.length ?? 1
 
-    if (rendering.calculatedTextBounds !== undefined) {
-        const textWidth = rendering.calculatedTextBounds.width
-        const textHeight = rendering.calculatedTextBounds.height
+    if (rendering.properties['klighd.calculated.text.bounds'] as Bounds !== undefined) {
+        const textWidth = (rendering.properties['klighd.calculated.text.bounds'] as Bounds).width
+        const textHeight = (rendering.properties['klighd.calculated.text.bounds'] as Bounds).height
 
-        if (rendering.calculatedBounds !== undefined) {
-            const foundBounds = rendering.calculatedBounds
+        if (rendering.properties['klighd.lsp.calculated.bounds'] as Bounds !== undefined) {
+            const foundBounds = rendering.properties['klighd.lsp.calculated.bounds'] as Bounds
             bounds.x = calculateX(foundBounds.x, foundBounds.width, styles.kHorizontalAlignment, textWidth)
             bounds.y = calculateY(foundBounds.y, foundBounds.height, styles.kVerticalAlignment, lines)
             bounds.width = textWidth
@@ -430,7 +430,7 @@ export function findTextBoundsAndTransformationData(rendering: KText, styles: KS
         }
         // if no bounds have been found yet, they should be in the boundsMap
         if (bounds.x === undefined && context.boundsMap !== undefined) {
-            const foundBounds = findById(context.boundsMap, rendering.renderingId)
+            const foundBounds = findById(context.boundsMap, rendering.properties['klighd.lsp.rendering.id'] as string)
             if (bounds !== undefined) {
                 bounds.x = calculateX(foundBounds.x, foundBounds.width, styles.kHorizontalAlignment, textWidth)
                 bounds.y = calculateY(foundBounds.y, foundBounds.height, styles.kVerticalAlignment, lines)
@@ -439,8 +439,8 @@ export function findTextBoundsAndTransformationData(rendering: KText, styles: KS
             }
         }
         // If there is a decoration, calculate the bounds and decoration (containing a possible rotation) from that.
-        if (rendering.calculatedDecoration !== undefined) {
-            decoration = rendering.calculatedDecoration
+        if (rendering.properties['klighd.lsp.calculated.decoration'] as Decoration !== undefined) {
+            decoration = rendering.properties['klighd.lsp.calculated.decoration'] as Decoration
             bounds.x = calculateX(decoration.bounds.x + decoration.origin.x, textWidth, styles.kHorizontalAlignment, textWidth)
             bounds.y = calculateY(decoration.bounds.y + decoration.origin.y, textHeight, styles.kVerticalAlignment, lines)
             bounds.width = decoration.bounds.width
@@ -448,7 +448,7 @@ export function findTextBoundsAndTransformationData(rendering: KText, styles: KS
         }
         // Same as above, if the decoration has not been found yet, it should be in the decorationMap.
         if (decoration === undefined && context.decorationMap !== undefined) {
-            decoration = findById(context.decorationMap, rendering.renderingId)
+            decoration = findById(context.decorationMap, rendering.properties['klighd.lsp.rendering.id'] as string)
             if (decoration !== undefined) {
                 bounds.x = calculateX(decoration.bounds.x + decoration.origin.x, textWidth, styles.kHorizontalAlignment, textWidth)
                 bounds.y = calculateY(decoration.bounds.y + decoration.origin.y, textHeight, styles.kVerticalAlignment, lines)

--- a/packages/klighd-core/src/views-rendering.tsx
+++ b/packages/klighd-core/src/views-rendering.tsx
@@ -1065,8 +1065,8 @@ export function getKRendering(datas: KGraphData[], context: SKGraphModelRenderer
                 const id = (data as KRenderingRef).properties['klighd.lsp.rendering.id'] as string
                 for (const rendering of context.kRenderingLibrary.renderings) {
                     if ((rendering as KRendering).properties['klighd.lsp.rendering.id'] as string === id) {
-                        context.boundsMap = (data as KRenderingRef).calculatedBoundsMap
-                        context.decorationMap = (data as KRenderingRef).calculatedDecorationMap
+                        context.boundsMap = (data as KRenderingRef).properties['klighd.lsp.calculated.bounds.map']
+                        context.decorationMap = (data as KRenderingRef).properties['klighd.lsp.calculated.decoration.map']
                         return rendering as KRendering
                     }
                 }

--- a/packages/klighd-core/src/views-rendering.tsx
+++ b/packages/klighd-core/src/views-rendering.tsx
@@ -50,7 +50,7 @@ export function renderChildArea(rendering: KChildArea, parent: SKGraphElement, p
     // remember, that this parent's children are now already rendered
     parent.areChildAreaChildrenRendered = true
 
-    const element = <g id={rendering.renderingId}>
+    const element = <g id={rendering.properties['klighd.lsp.rendering.id'] as string}>
         {context.renderChildAreaChildren(parent)}
     </g>
 
@@ -153,7 +153,7 @@ export function renderRectangularShape(
                     }
                 }
 
-                element = <g id={rendering.renderingId} {...gAttrs}>
+                element = <g id={rendering.properties['klighd.lsp.rendering.id'] as string} {...gAttrs}>
                     {...renderSVGArc(lineStyles, colorStyles, shadowStyles, d, styles.kShadow)}
                     {renderChildRenderings(rendering, parent, stylesToPropagate, context, childOfNodeTitle)}
                 </g>
@@ -164,7 +164,7 @@ export function renderRectangularShape(
         }
         // eslint-disable-next-line
         case K_ELLIPSE: {
-            element = <g id={rendering.renderingId} {...gAttrs}>
+            element = <g id={rendering.properties['klighd.lsp.rendering.id'] as string} {...gAttrs}>
                 {...renderSVGEllipse(boundsAndTransformation.bounds, lineStyles, colorStyles, shadowStyles, styles.kShadow)}
                 {renderChildRenderings(rendering, parent, stylesToPropagate, context, childOfNodeTitle)}
             </g>
@@ -179,7 +179,7 @@ export function renderRectangularShape(
             const rx = (rendering as KRoundedRectangle).cornerWidth
             const ry = (rendering as KRoundedRectangle).cornerHeight
 
-            element = <g id={rendering.renderingId} {...gAttrs}>
+            element = <g id={rendering.properties['klighd.lsp.rendering.id'] as string} {...gAttrs}>
                 {...renderSVGRect(boundsAndTransformation.bounds, rx, ry, lineStyles, colorStyles, shadowStyles, styles.kShadow)}
                 {renderChildRenderings(rendering, parent, stylesToPropagate, context, childOfNodeTitle)}
             </g>
@@ -190,7 +190,7 @@ export function renderRectangularShape(
             const id = (rendering as KImage).bundleName + ':' + (rendering as KImage).imagePath
             const extension = id.slice(id.lastIndexOf('.') + 1)
             const image = 'data:image/' + extension + ';base64,' + sessionStorage.getItem(id)
-            element = <g id={rendering.renderingId} {...gAttrs}>
+            element = <g id={rendering.properties['klighd.lsp.rendering.id'] as string} {...gAttrs}>
                 {...renderSVGImage(boundsAndTransformation.bounds, shadowStyles, image, styles.kShadow)}
             </g>
             break
@@ -359,7 +359,7 @@ export function renderLine(rendering: KPolyline,
 
     // Create the svg element for this rendering.
     // Only apply the fast shadow to KPolygons, other shadows are not allowed there.
-    const element = <g id={rendering.renderingId} {...gAttrs}>
+    const element = <g id={rendering.properties['klighd.lsp.rendering.id'] as string} {...gAttrs}>
         {...renderSVGLine(lineStyles, colorStyles, shadowStyles, path, rendering.type == K_POLYGON ? styles.kShadow : undefined)}
         {renderChildRenderings(rendering, parent, stylesToPropagate, context, childOfNodeTitle)}
     </g>
@@ -414,25 +414,25 @@ export function renderKText(rendering: KText,
     // Replace text with rectangle, if the text is too small.
     const simplifySmallTextOption = context.renderOptionsRegistry.getValue(SimplifySmallText)
     const simplifySmallText = simplifySmallTextOption ?? false // Only enable, if option is found.
-    if (simplifySmallText && !rendering.isNodeTitle && !childOfNodeTitle) {
+    if (simplifySmallText && !rendering.properties['klighd.isNodeTitle'] as boolean && !childOfNodeTitle) {
         const simplificationThreshold = context.renderOptionsRegistry.getValueOrDefault(TextSimplificationThreshold)
 
         const proportionalHeight = 0.5 // height of replacement compared to full text height
-        if (context.viewport && rendering.calculatedTextBounds
-            && rendering.calculatedTextBounds.height * context.viewport.zoom <= simplificationThreshold) {
+        if (context.viewport && rendering.properties['klighd.calculated.text.bounds'] as Bounds
+            && (rendering.properties['klighd.calculated.text.bounds'] as Bounds).height * context.viewport.zoom <= simplificationThreshold) {
             const replacements: VNode[] = []
             lines.forEach((line, index) => {
                 const xPos = boundsAndTransformation && boundsAndTransformation.bounds.x ? boundsAndTransformation.bounds.x : 0
-                const yPos = boundsAndTransformation && boundsAndTransformation.bounds.y && rendering.calculatedTextLineHeights && boundsAndTransformation.bounds.height ?
-                    boundsAndTransformation.bounds.y - boundsAndTransformation.bounds.height / 2 + rendering.calculatedTextLineHeights[index] / 2 * proportionalHeight : 0
-                const width = rendering.calculatedTextLineWidths ? rendering.calculatedTextLineWidths[index] : 0
-                const height = rendering.calculatedTextLineHeights ? rendering.calculatedTextLineHeights[index] * proportionalHeight : 0
+                const yPos = boundsAndTransformation && boundsAndTransformation.bounds.y && rendering.properties['klighd.calculated.text.line.heights'] as number[] && boundsAndTransformation.bounds.height ?
+                    boundsAndTransformation.bounds.y - boundsAndTransformation.bounds.height / 2 + (rendering.properties['klighd.calculated.text.line.heights'] as number[])[index] / 2 * proportionalHeight : 0
+                const width = rendering.properties['klighd.calculated.text.line.widths'] as number[] ? (rendering.properties['klighd.calculated.text.line.widths'] as number[])[index] : 0
+                const height = rendering.properties['klighd.calculated.text.line.heights'] as number[] ? (rendering.properties['klighd.calculated.text.line.heights'] as number[])[index] * proportionalHeight : 0
                 // Generate rectangle for each line with color style.
                 const curLine = colorStyle ? <rect x={xPos} y={yPos} width={width} height={height} fill={colorStyle.color} />
                     : <rect x={xPos} y={yPos} width={width} height={height} fill="#000000" />
                 replacements.push(curLine)
             });
-            return <g id={rendering.renderingId} {...{}}>
+            return <g id={rendering.properties['klighd.lsp.rendering.id'] as string} {...{}}>
                 {...replacements}
             </g>
         }
@@ -469,8 +469,8 @@ export function renderKText(rendering: KText,
         // Force any SVG renderer rendering this text to use the exact width calculated for it.
         // This avoids overlapping texts or too big gaps at the cost of slightly bigger/tighter glyph spacings
         // when viewed in a different SVG viewer after exporting.
-        if (rendering.calculatedTextLineWidths) {
-            attrs.textLength = rendering.calculatedTextLineWidths[0]
+        if (rendering.properties['klighd.calculated.text.line.widths'] as number[]) {
+            attrs.textLength = rendering.properties['klighd.calculated.text.line.widths'] as number[][0]
             attrs.lengthAdjust = 'spacingAndGlyphs'
         }
 
@@ -481,10 +481,10 @@ export function renderKText(rendering: KText,
         ]
     } else {
         // Otherwise, put each line of text in a separate <text> element.
-        const calculatedTextLineWidths = rendering.calculatedTextLineWidths
-        const calculatedTextLineHeights = rendering.calculatedTextLineHeights
+        const calculatedTextLineWidths = rendering.properties['klighd.calculated.text.line.widths'] as number[]
+        const calculatedTextLineHeights = rendering.properties['klighd.calculated.text.line.heights'] as number[]
         let currentY = boundsAndTransformation.bounds.y ? boundsAndTransformation.bounds.y : 0
-        if (rendering.calculatedTextLineWidths) {
+        if (rendering.properties['klighd.calculated.text.line.widths'] as number[]) {
             attrs.lengthAdjust = 'spacingAndGlyphs'
         }
 
@@ -506,7 +506,7 @@ export function renderKText(rendering: KText,
         ...(boundsAndTransformation.transformation !== undefined ? { transform: boundsAndTransformation.transformation } : {})
     }
     // build the element from the above defined attributes and children
-    return <g id={rendering.renderingId} {...gAttrs}>
+    return <g id={rendering.properties['klighd.lsp.rendering.id'] as string} {...gAttrs}>
         {...elements}
     </g>
 }
@@ -537,7 +537,7 @@ export function renderError(rendering: KRendering): VNode {
     return <text>
         {'Rendering cannot be drawn!\n' +
             'Type: ' + rendering.type + '\n' +
-            'ID: ' + rendering.renderingId}
+            'ID: ' + rendering.properties['klighd.lsp.rendering.id'] as string}
     </text>
 }
 
@@ -897,7 +897,7 @@ export function renderKRendering(kRendering: KRendering,
 
     // If this rendering is the main title rendering of the element, either render it usually if
     // zoomed in far enough or remember it to be rendered later scaled up and overlayed on top of the parent rendering.
-    if (context.depthMap && boundsAndTransformation.bounds.width && boundsAndTransformation.bounds.height && kRendering.isNodeTitle) {
+    if (context.depthMap && boundsAndTransformation.bounds.width && boundsAndTransformation.bounds.height && kRendering.properties['klighd.isNodeTitle'] as boolean) {
         // Scale to limit of bounding box or max size.
         const titleScalingFactorOption = context.renderOptionsRegistry.getValueOrDefault(TitleScalingFactor) as number
         let maxScale = titleScalingFactorOption
@@ -905,7 +905,7 @@ export function renderKRendering(kRendering: KRendering,
             maxScale = maxScale / context.viewport.zoom
         }
         if (providingRegion && providingRegion.detail !== DetailLevel.FullDetails && parent.children.length > 1
-            || kRendering.calculatedBounds && kRendering.calculatedBounds.height * context.viewport.zoom <= titleScalingFactorOption * kRendering.calculatedBounds.height) {
+            || kRendering.properties['klighd.lsp.calculated.bounds'] as Bounds && (kRendering.properties['klighd.lsp.calculated.bounds'] as Bounds).height * context.viewport.zoom <= titleScalingFactorOption * (kRendering.properties['klighd.lsp.calculated.bounds'] as Bounds).height) {
             isOverlay = true
 
             let boundingBox = boundsAndTransformation.bounds
@@ -954,10 +954,10 @@ export function renderKRendering(kRendering: KRendering,
                 boundsAndTransformation.transformation = translateAndScale
             }
             // For text renderings, recalculate the required bounds the text needs with the updated data.
-            if (kRendering.type === K_TEXT && (kRendering as KText).calculatedTextBounds) {
+            if (kRendering.type === K_TEXT && (kRendering as KText).properties['klighd.calculated.text.bounds'] as Bounds) {
                 const rendering = kRendering as KText
                 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                const textWidth = rendering.calculatedTextBounds!.width
+                const textWidth = (rendering.properties['klighd.calculated.text.bounds'] as Bounds)!.width
 
                 // text centered in its new bounding box around local 0,0 coordinates
                 styles.kHorizontalAlignment = {
@@ -987,8 +987,8 @@ export function renderKRendering(kRendering: KRendering,
                 providingRegion.regionTitleIndentation = newX
             }
             // Draw white background for overlaying titles
-            if (context.depthMap && kRendering.isNodeTitle && ((providingRegion && providingRegion.detail === DetailLevel.FullDetails) || !providingRegion)
-                && kRendering.calculatedBounds && kRendering.calculatedBounds.height * context.viewport.zoom <= titleScalingFactorOption * kRendering.calculatedBounds.height
+            if (context.depthMap && kRendering.properties['klighd.isNodeTitle'] as boolean && ((providingRegion && providingRegion.detail === DetailLevel.FullDetails) || !providingRegion)
+                && kRendering.properties['klighd.lsp.calculated.bounds'] as Bounds && (kRendering.properties['klighd.lsp.calculated.bounds'] as Bounds).height * context.viewport.zoom <= titleScalingFactorOption * (kRendering.properties['klighd.lsp.calculated.bounds'] as Bounds).height
                 // Don't draw if the rendering is an empty KText
                 && (kRendering.type !== K_TEXT || (kRendering as KText).text !== "")) {
                 overlayRectangle = <rect x={0} y={0} width={originalWidth} height={originalHeight} fill="white" opacity="0.8" stroke="black" />
@@ -1061,9 +1061,9 @@ export function getKRendering(datas: KGraphData[], context: SKGraphModelRenderer
             continue
         if (data.type === K_RENDERING_REF) {
             if (context.kRenderingLibrary) {
-                const id = (data as KRenderingRef).renderingId
+                const id = (data as KRenderingRef).properties['klighd.lsp.rendering.id'] as string
                 for (const rendering of context.kRenderingLibrary.renderings) {
-                    if ((rendering as KRendering).renderingId === id) {
+                    if ((rendering as KRendering).properties['klighd.lsp.rendering.id'] as string === id) {
                         context.boundsMap = (data as KRenderingRef).calculatedBoundsMap
                         context.decorationMap = (data as KRenderingRef).calculatedDecorationMap
                         return rendering as KRendering

--- a/packages/klighd-core/src/views-rendering.tsx
+++ b/packages/klighd-core/src/views-rendering.tsx
@@ -219,7 +219,7 @@ export function renderRectangularShape(
             const placeholder = <g
                 transform={`scale(${scalingFactor}, ${scalingFactor}) translate(${x}, ${y})`}>
                 <circle cx="11" cy="11" r="8" stroke="#000000" fill="none" />
-                <line x1="21" x2="16.65" y1="21" y2="16.65" stroke="#000000" style={{'stroke-linecap': 'round', 'stroke-width': '2'}}/>
+                <line x1="21" x2="16.65" y1="21" y2="16.65" stroke="#000000" style={{ 'stroke-linecap': 'round', 'stroke-width': '2' }} />
                 <line x1="11" x2="11" y1="8" y2="14" stroke="#000000" stroke-linecap="round" />
                 <line x1="8" x2="14" y1="11" y2="11" stroke="#000000" stroke-linecap="round" />
             </g>
@@ -388,6 +388,9 @@ export function renderKText(rendering: KText,
     } else {
         text = rendering.text
     }
+    if (parent.properties["de.cau.cs.kieler.klighd.labels.textOverride"] !== undefined) {
+        text = parent.properties["de.cau.cs.kieler.klighd.labels.textOverride"] as string
+    }
     // If no text can be found, return here.
     if (text === undefined) return <g />
 
@@ -455,7 +458,7 @@ export function renderKText(rendering: KText,
         x: boundsAndTransformation.bounds.x,
         style: style,
         ...(colorStyle ? { fill: colorStyle.color } : {}),
-        ...(shadowStyles ? {filter: shadowStyles} : {}),
+        ...(shadowStyles ? { filter: shadowStyles } : {}),
         ...{ 'xml:space': 'preserve' } // This attribute makes the text size adjustment include any trailing white spaces.
     } as any
 
@@ -470,7 +473,7 @@ export function renderKText(rendering: KText,
             attrs.textLength = rendering.calculatedTextLineWidths[0]
             attrs.lengthAdjust = 'spacingAndGlyphs'
         }
-        
+
         elements = [
             <text {...attrs}>
                 {...lines}
@@ -621,18 +624,18 @@ export function renderSingleSVGRect(x: number | undefined, y: number | undefined
         {...(rx ? { rx: rx } : {})}
         {...(ry ? { ry: ry } : {})}
         style={{
-            ...(kShadow ? {} : {'stroke-linecap': lineStyles.lineCap}),
-            ...(kShadow ? {} : {'stroke-linejoin': lineStyles.lineJoin}),
-            ...(kShadow ? {} : {'stroke-width': lineStyles.lineWidth}),
-            ...(kShadow ? {} : {'stroke-dasharray': lineStyles.dashArray}),
-            ...(kShadow ? {} : {'stroke-miterlimit': lineStyles.miterLimit}),
+            ...(kShadow ? {} : { 'stroke-linecap': lineStyles.lineCap }),
+            ...(kShadow ? {} : { 'stroke-linejoin': lineStyles.lineJoin }),
+            ...(kShadow ? {} : { 'stroke-width': lineStyles.lineWidth }),
+            ...(kShadow ? {} : { 'stroke-dasharray': lineStyles.dashArray }),
+            ...(kShadow ? {} : { 'stroke-miterlimit': lineStyles.miterLimit }),
             'opacity': kShadow ? colorStyles.opacity ? String(Number(colorStyles.opacity) * 0.1) : '0.1' : colorStyles.opacity,
-            ...(kShadow ? {} : {'stroke-opacity': colorStyles.foreground.opacity}),
-            ...(kShadow || colorStyles.background.opacity ? {'fill-opacity': kShadow ? '1' : colorStyles.background.opacity} : {})
+            ...(kShadow ? {} : { 'stroke-opacity': colorStyles.foreground.opacity }),
+            ...(kShadow || colorStyles.background.opacity ? { 'fill-opacity': kShadow ? '1' : colorStyles.background.opacity } : {})
         }}
-        {...(kShadow ? {} : {stroke: colorStyles.foreground.color})}
-        {...(kShadow ? {fill:'rgb(0,0,0)'} : {fill: colorStyles.background.color})}
-        {...(shadowStyles ? {filter: shadowStyles} : {})}
+        {...(kShadow ? {} : { stroke: colorStyles.foreground.color })}
+        {...(kShadow ? { fill: 'rgb(0,0,0)' } : { fill: colorStyles.background.color })}
+        {...(shadowStyles ? { filter: shadowStyles } : {})}
     />
 }
 
@@ -677,7 +680,7 @@ export function renderSingleSVGImage(x: number | undefined, y: number | undefine
             width={bounds.width}
             height={bounds.height}
             href={image}
-            {...(shadowStyles ? {filter: shadowStyles} : {})}
+            {...(shadowStyles ? { filter: shadowStyles } : {})}
         />
     }
 }
@@ -694,7 +697,7 @@ export function renderSingleSVGImage(x: number | undefined, y: number | undefine
  */
 export function renderSVGArc(lineStyles: LineStyles, colorStyles: ColorStyles, shadowStyles: string | undefined, path: string, kShadow: KShadow | undefined): VNode[] {
     return renderWithShadow(kShadow, shadowStyles, renderSingleSVGArc, lineStyles, colorStyles, path)
-} 
+}
 
 /**
  * Renders an arc with all given information.
@@ -715,18 +718,18 @@ export function renderSingleSVGArc(x: number | undefined, y: number | undefined,
         {...(x && y ? { transform: `translate(${x},${y})` } : {})}
         d={path}
         style={{
-            ...(kShadow ? {} : {'stroke-linecap': lineStyles.lineCap}),
-            ...(kShadow ? {} : {'stroke-linejoin': lineStyles.lineJoin}),
-            ...(kShadow ? {} : {'stroke-width': lineStyles.lineWidth}),
-            ...(kShadow ? {} : {'stroke-dasharray': lineStyles.dashArray}),
-            ...(kShadow ? {} : {'stroke-miterlimit': lineStyles.miterLimit}),
+            ...(kShadow ? {} : { 'stroke-linecap': lineStyles.lineCap }),
+            ...(kShadow ? {} : { 'stroke-linejoin': lineStyles.lineJoin }),
+            ...(kShadow ? {} : { 'stroke-width': lineStyles.lineWidth }),
+            ...(kShadow ? {} : { 'stroke-dasharray': lineStyles.dashArray }),
+            ...(kShadow ? {} : { 'stroke-miterlimit': lineStyles.miterLimit }),
             'opacity': kShadow ? colorStyles.opacity ? String(Number(colorStyles.opacity) * 0.1) : '0.1' : colorStyles.opacity,
-            ...(kShadow ? {} : {'stroke-opacity': colorStyles.foreground.opacity}),
-            ...(kShadow || colorStyles.background.opacity ? {'fill-opacity': kShadow ? '1' : colorStyles.background.opacity} : {})
+            ...(kShadow ? {} : { 'stroke-opacity': colorStyles.foreground.opacity }),
+            ...(kShadow || colorStyles.background.opacity ? { 'fill-opacity': kShadow ? '1' : colorStyles.background.opacity } : {})
         }}
-        {...(kShadow ? {} : {stroke: colorStyles.foreground.color})}
-        {...(kShadow ? {fill:'rgb(0,0,0)'} : {fill: colorStyles.background.color})}
-        {...(shadowStyles ? {filter: shadowStyles} : {})}
+        {...(kShadow ? {} : { stroke: colorStyles.foreground.color })}
+        {...(kShadow ? { fill: 'rgb(0,0,0)' } : { fill: colorStyles.background.color })}
+        {...(shadowStyles ? { filter: shadowStyles } : {})}
     />
 }
 
@@ -765,18 +768,18 @@ export function renderSingleSVGEllipse(x: number | undefined, y: number | undefi
         rx={bounds.width / 2}
         ry={bounds.height / 2}
         style={{
-            ...(kShadow ? {} : {'stroke-linecap': lineStyles.lineCap}),
-            ...(kShadow ? {} : {'stroke-linejoin': lineStyles.lineJoin}),
-            ...(kShadow ? {} : {'stroke-width': lineStyles.lineWidth}),
-            ...(kShadow ? {} : {'stroke-dasharray': lineStyles.dashArray}),
-            ...(kShadow ? {} : {'stroke-miterlimit': lineStyles.miterLimit}),
+            ...(kShadow ? {} : { 'stroke-linecap': lineStyles.lineCap }),
+            ...(kShadow ? {} : { 'stroke-linejoin': lineStyles.lineJoin }),
+            ...(kShadow ? {} : { 'stroke-width': lineStyles.lineWidth }),
+            ...(kShadow ? {} : { 'stroke-dasharray': lineStyles.dashArray }),
+            ...(kShadow ? {} : { 'stroke-miterlimit': lineStyles.miterLimit }),
             'opacity': kShadow ? colorStyles.opacity ? String(Number(colorStyles.opacity) * 0.1) : '0.1' : colorStyles.opacity,
-            ...(kShadow ? {} : {'stroke-opacity': colorStyles.foreground.opacity}),
-            ...(kShadow || colorStyles.background.opacity ? {'fill-opacity': kShadow ? '1' : colorStyles.background.opacity} : {})
+            ...(kShadow ? {} : { 'stroke-opacity': colorStyles.foreground.opacity }),
+            ...(kShadow || colorStyles.background.opacity ? { 'fill-opacity': kShadow ? '1' : colorStyles.background.opacity } : {})
         }}
-        {...(kShadow ? {} : {stroke: colorStyles.foreground.color})}
-        {...(kShadow ? {fill:'rgb(0,0,0)'} : {fill: colorStyles.background.color})}
-        {...(shadowStyles ? {filter: shadowStyles} : {})}
+        {...(kShadow ? {} : { stroke: colorStyles.foreground.color })}
+        {...(kShadow ? { fill: 'rgb(0,0,0)' } : { fill: colorStyles.background.color })}
+        {...(shadowStyles ? { filter: shadowStyles } : {})}
     />
 }
 
@@ -813,18 +816,18 @@ export function renderSingleSVGLine(x: number | undefined, y: number | undefined
         {...(x && y ? { transform: `translate(${x},${y})` } : {})}
         d={path}
         style={{
-            ...(kShadow ? {} : {'stroke-linecap': lineStyles.lineCap}),
-            ...(kShadow ? {} : {'stroke-linejoin': lineStyles.lineJoin}),
-            ...(kShadow ? {} : {'stroke-width': lineStyles.lineWidth}),
-            ...(kShadow ? {} : {'stroke-dasharray': lineStyles.dashArray}),
-            ...(kShadow ? {} : {'stroke-miterlimit': lineStyles.miterLimit}),
+            ...(kShadow ? {} : { 'stroke-linecap': lineStyles.lineCap }),
+            ...(kShadow ? {} : { 'stroke-linejoin': lineStyles.lineJoin }),
+            ...(kShadow ? {} : { 'stroke-width': lineStyles.lineWidth }),
+            ...(kShadow ? {} : { 'stroke-dasharray': lineStyles.dashArray }),
+            ...(kShadow ? {} : { 'stroke-miterlimit': lineStyles.miterLimit }),
             'opacity': kShadow ? colorStyles.opacity ? String(Number(colorStyles.opacity) * 0.1) : '0.1' : colorStyles.opacity,
-            ...(kShadow ? {} : {'stroke-opacity': colorStyles.foreground.opacity}),
-            ...(kShadow || colorStyles.background.opacity ? {'fill-opacity': kShadow ? '1' : colorStyles.background.opacity} : {})
+            ...(kShadow ? {} : { 'stroke-opacity': colorStyles.foreground.opacity }),
+            ...(kShadow || colorStyles.background.opacity ? { 'fill-opacity': kShadow ? '1' : colorStyles.background.opacity } : {})
         }}
-        {...(kShadow ? {} : {stroke: colorStyles.foreground.color})}
-        {...(kShadow ? {fill:'rgb(0,0,0)'} : {fill: colorStyles.background.color})}
-        {...(shadowStyles ? {filter: shadowStyles} : {})}
+        {...(kShadow ? {} : { stroke: colorStyles.foreground.color })}
+        {...(kShadow ? { fill: 'rgb(0,0,0)' } : { fill: colorStyles.background.color })}
+        {...(shadowStyles ? { filter: shadowStyles } : {})}
     />
 }
 
@@ -875,7 +878,7 @@ export function renderKRendering(kRendering: KRendering,
     const styles = getKStyles(parent, kRendering.styles, propagatedStyles, stylesToPropagate)
 
     // Determine the bounds of the rendering first and where it has to be placed.
-    const isEdge = [K_POLYLINE,  K_POLYGON, K_ROUNDED_BENDS_POLYLINE, K_SPLINE].includes(kRendering.type)
+    const isEdge = [K_POLYLINE, K_POLYGON, K_ROUNDED_BENDS_POLYLINE, K_SPLINE].includes(kRendering.type)
     const boundsAndTransformation = findBoundsAndTransformationData(kRendering, styles, parent, context, isEdge)
     if (boundsAndTransformation === undefined) {
         // If no bounds are found, the rendering can not be drawn.
@@ -891,7 +894,7 @@ export function renderKRendering(kRendering: KRendering,
     let overlayRectangle: VNode | undefined = undefined
     // remembers if this rendering is a title rendering and should therefore be rendered overlaying the other renderings.
     let isOverlay = false
-    
+
     // If this rendering is the main title rendering of the element, either render it usually if
     // zoomed in far enough or remember it to be rendered later scaled up and overlayed on top of the parent rendering.
     if (context.depthMap && boundsAndTransformation.bounds.width && boundsAndTransformation.bounds.height && kRendering.isNodeTitle) {
@@ -910,8 +913,8 @@ export function renderKRendering(kRendering: KRendering,
             if (kRendering.type === K_TEXT) {
                 boundingBox = findBoundsAndTransformationData(kRendering, styles, parent, context, isEdge, true)?.bounds ?? boundingBox
             }
-            
-            
+
+
             const parentBounds = providingRegion ? providingRegion.boundingRectangle.bounds : (parent as KNode).bounds
             const originalWidth = boundingBox.width
             const originalHeight = boundingBox.height
@@ -923,7 +926,7 @@ export function renderKRendering(kRendering: KRendering,
             // Don't let scalingfactor get too big.
             let scalingFactor = Math.min(maxScaleX, maxScaleY, maxScale)
             // Make sure we never scale down.
-            scalingFactor = Math.max(scalingFactor,  1)
+            scalingFactor = Math.max(scalingFactor, 1)
 
             // Calculate the new x and y indentation:
             // width required of scaled rendering
@@ -988,7 +991,7 @@ export function renderKRendering(kRendering: KRendering,
                 && kRendering.calculatedBounds && kRendering.calculatedBounds.height * context.viewport.zoom <= titleScalingFactorOption * kRendering.calculatedBounds.height
                 // Don't draw if the rendering is an empty KText
                 && (kRendering.type !== K_TEXT || (kRendering as KText).text !== "")) {
-                overlayRectangle = <rect x={0} y={0} width={originalWidth} height={originalHeight} fill="white" opacity="0.8" stroke="black"/>
+                overlayRectangle = <rect x={0} y={0} width={originalWidth} height={originalHeight} fill="white" opacity="0.8" stroke="black" />
             }
         }
     }

--- a/packages/klighd-core/src/views.tsx
+++ b/packages/klighd-core/src/views.tsx
@@ -118,7 +118,7 @@ export class KNodeView implements IView {
             shadow = getRendering(node.data, node, new KStyles, ctx)
         }
         if (isChildSelected(node as SKNode)) {
-            if (((node as SKNode).properties.get("org.eclipse.elk.interactiveLayout")) && ctx.mListener.hasDragged) {
+            if (((node as SKNode).properties.get('org.eclipse.elk.interactiveLayout')) && ctx.mListener.hasDragged) {
                 // Render the objects indicating the layer and positions in the graph
                 interactiveNodes = renderInteractiveLayout(node as SKNode)
             }
@@ -131,7 +131,7 @@ export class KNodeView implements IView {
             // Node should only be visible if the node is in the same hierarchical level as the moved node or no node is moved at all
             rendering = getRendering(node.data, node, new KStyles, ctx)
 
-            if (ctx.renderOptionsRegistry.getValue(ShowConstraintOption) && (node.parent as SKNode).properties && (node.parent as SKNode).properties.get("org.eclipse.elk.interactiveLayout")) {
+            if (ctx.renderOptionsRegistry.getValue(ShowConstraintOption) && (node.parent as SKNode).properties && (node.parent as SKNode).properties.get('org.eclipse.elk.interactiveLayout')) {
                 // render icon visualizing the set Constraints
                 interactiveConstraints = renderConstraints(node)
             }

--- a/packages/klighd-core/src/views.tsx
+++ b/packages/klighd-core/src/views.tsx
@@ -118,7 +118,7 @@ export class KNodeView implements IView {
             shadow = getRendering(node.data, node, new KStyles, ctx)
         }
         if (isChildSelected(node as SKNode)) {
-            if (((node as SKNode).properties.interactiveLayout) && ctx.mListener.hasDragged) {
+            if (((node as SKNode).properties.get("org.eclipse.elk.interactiveLayout")) && ctx.mListener.hasDragged) {
                 // Render the objects indicating the layer and positions in the graph
                 interactiveNodes = renderInteractiveLayout(node as SKNode)
             }
@@ -131,7 +131,7 @@ export class KNodeView implements IView {
             // Node should only be visible if the node is in the same hierarchical level as the moved node or no node is moved at all
             rendering = getRendering(node.data, node, new KStyles, ctx)
 
-            if (ctx.renderOptionsRegistry.getValue(ShowConstraintOption) && (node.parent as SKNode).properties && (node.parent as SKNode).properties.interactiveLayout) {
+            if (ctx.renderOptionsRegistry.getValue(ShowConstraintOption) && (node.parent as SKNode).properties && (node.parent as SKNode).properties.get("org.eclipse.elk.interactiveLayout")) {
                 // render icon visualizing the set Constraints
                 interactiveConstraints = renderConstraints(node)
             }
@@ -237,7 +237,7 @@ export class KPortView implements IView {
         const rendering = getRendering(port.data, port, new KStyles, ctx)
         // If no rendering could be found, just render its children.
         if (rendering === undefined) {
-            const element =  <g>
+            const element = <g>
                 {ctx.titles.pop() ?? []}
                 {ctx.renderChildren(port)}
             </g>
@@ -277,7 +277,7 @@ export class KPortView implements IView {
 @injectable()
 export class KLabelView implements IView {
 
-    render(label: SKLabel, context: RenderingContext): VNode | undefined{
+    render(label: SKLabel, context: RenderingContext): VNode | undefined {
         // Add new level to title and position array for correct placement of titles
         const ctx = context as SKGraphModelRenderer
 

--- a/packages/klighd-core/src/views.tsx
+++ b/packages/klighd-core/src/views.tsx
@@ -118,7 +118,7 @@ export class KNodeView implements IView {
             shadow = getRendering(node.data, node, new KStyles, ctx)
         }
         if (isChildSelected(node as SKNode)) {
-            if (((node as SKNode).properties.get('org.eclipse.elk.interactiveLayout')) && ctx.mListener.hasDragged) {
+            if (((node as SKNode).properties['org.eclipse.elk.interactiveLayout']) && ctx.mListener.hasDragged) {
                 // Render the objects indicating the layer and positions in the graph
                 interactiveNodes = renderInteractiveLayout(node as SKNode)
             }
@@ -131,7 +131,7 @@ export class KNodeView implements IView {
             // Node should only be visible if the node is in the same hierarchical level as the moved node or no node is moved at all
             rendering = getRendering(node.data, node, new KStyles, ctx)
 
-            if (ctx.renderOptionsRegistry.getValue(ShowConstraintOption) && (node.parent as SKNode).properties && (node.parent as SKNode).properties.get('org.eclipse.elk.interactiveLayout')) {
+            if (ctx.renderOptionsRegistry.getValue(ShowConstraintOption) && (node.parent as SKNode).properties && (node.parent as SKNode).properties['org.eclipse.elk.interactiveLayout']) {
                 // render icon visualizing the set Constraints
                 interactiveConstraints = renderConstraints(node)
             }

--- a/packages/klighd-interactive/src/constraint-classes.ts
+++ b/packages/klighd-interactive/src/constraint-classes.ts
@@ -52,10 +52,11 @@ export class KNode extends RectangularNode implements KGraphElement {
     areChildAreaChildrenRendered = false
     areNonChildAreaChildrenRendered = false
     hasFeature(feature: symbol): boolean {
-        return feature === selectFeature || (feature === moveFeature && (this.parent as KNode).properties.interactiveLayout)
+        return feature === selectFeature || (feature === moveFeature && (this.parent as KNode).properties.get("org.eclipse.elk.interactiveLayout") as boolean)
     }
 
-    properties: NodeProperties
+    //properties: NodeProperties
+    properties: Map<string, unknown>
 
     direction: Direction
 

--- a/packages/klighd-interactive/src/constraint-classes.ts
+++ b/packages/klighd-interactive/src/constraint-classes.ts
@@ -52,11 +52,11 @@ export class KNode extends RectangularNode implements KGraphElement {
     areChildAreaChildrenRendered = false
     areNonChildAreaChildrenRendered = false
     hasFeature(feature: symbol): boolean {
-        return feature === selectFeature || (feature === moveFeature && (this.parent as KNode).properties.get("org.eclipse.elk.interactiveLayout") as boolean)
+        return feature === selectFeature || (feature === moveFeature && (this.parent as KNode).properties.get('org.eclipse.elk.interactiveLayout') as boolean)
     }
 
     //properties: NodeProperties
-    properties: Map<string, unknown>
+    properties: Map<string, unknown> = new Map();
 
     direction: Direction
 

--- a/packages/klighd-interactive/src/constraint-classes.ts
+++ b/packages/klighd-interactive/src/constraint-classes.ts
@@ -52,11 +52,11 @@ export class KNode extends RectangularNode implements KGraphElement {
     areChildAreaChildrenRendered = false
     areNonChildAreaChildrenRendered = false
     hasFeature(feature: symbol): boolean {
-        return feature === selectFeature || (feature === moveFeature && (this.parent as KNode).properties.get('org.eclipse.elk.interactiveLayout') as boolean)
+        return feature === selectFeature || (feature === moveFeature && (this.parent as KNode).properties['org.eclipse.elk.interactiveLayout'] as boolean)
     }
 
     //properties: NodeProperties
-    properties: Map<string, unknown> = new Map();
+    properties: Record<string, unknown>
 
     direction: Direction
 

--- a/packages/klighd-interactive/src/constraint-classes.ts
+++ b/packages/klighd-interactive/src/constraint-classes.ts
@@ -55,7 +55,6 @@ export class KNode extends RectangularNode implements KGraphElement {
         return feature === selectFeature || (feature === moveFeature && (this.parent as KNode).properties['org.eclipse.elk.interactiveLayout'] as boolean)
     }
 
-    //properties: NodeProperties
     properties: Record<string, unknown>
 
     direction: Direction
@@ -71,23 +70,6 @@ export enum Direction {
     LEFT,
     DOWN,
     UP
-}
-
-/**
- * Properties needed for client side layout or visualization.
- * Send together with the nodes from server to client.
- * They correspond to properties on the server.
- */
-export class NodeProperties {
-    algorithm: string
-    aspectRatio: number
-    currentPosition: number
-    desiredPosition: number
-    interactiveLayout: boolean
-    layerConstraint: number
-    layerId: number
-    positionConstraint: number
-    positionId: number
 }
 
 /**

--- a/packages/klighd-interactive/src/interactive-view.tsx
+++ b/packages/klighd-interactive/src/interactive-view.tsx
@@ -30,9 +30,9 @@ export function renderInteractiveLayout(root: KNode): VNode {
     // Filter KNodes
     const nodes = filterKNodes(root.children)
     let result = undefined
-    if (root.properties.get('org.eclipse.elk.algorithm') === undefined || (root.properties.get('org.eclipse.elk.algorithm') as string).endsWith('layered')) {
+    if (root.properties['org.eclipse.elk.algorithm'] === undefined || (root.properties['org.eclipse.elk.algorithm'] as string).endsWith('layered')) {
         result = renderHierarchyLevelLayered(nodes)
-    } else if ((root.properties.get('org.eclipse.elk.algorithm') as string).endsWith('rectpacking')) {
+    } else if ((root.properties['org.eclipse.elk.algorithm'] as string).endsWith('rectpacking')) {
         result = renderHierarchyLevelRectPacking(nodes)
     } else {
         // Not supported
@@ -49,11 +49,11 @@ export function renderInteractiveLayout(root: KNode): VNode {
  */
 export function renderConstraints(node: KNode): VNode {
     let result = <g></g>
-    const algorithm = (node.parent as KNode).properties.get('org.eclipse.elk.algorithm') as string
+    const algorithm = (node.parent as KNode).properties['org.eclipse.elk.algorithm'] as string
     if (algorithm === undefined || algorithm.endsWith('layered')) {
         result = renderLayeredConstraint(node)
     } else if (algorithm.endsWith('rectpacking')) {
-        if (node.properties.get('org.eclipse.elk.alg.rectpacking.desiredPosition') !== -1) {
+        if (node.properties['org.eclipse.elk.alg.rectpacking.desiredPosition'] !== -1) {
             result = renderRectPackConstraint(node)
         }
     } else {

--- a/packages/klighd-interactive/src/interactive-view.tsx
+++ b/packages/klighd-interactive/src/interactive-view.tsx
@@ -30,9 +30,9 @@ export function renderInteractiveLayout(root: KNode): VNode {
     // Filter KNodes
     const nodes = filterKNodes(root.children)
     let result = undefined
-    if (root.properties.get("org.eclipse.elk.algorithm") === undefined || (root.properties.get("org.eclipse.elk.algorithm") as string).endsWith('layered')) {
+    if (root.properties.get('org.eclipse.elk.algorithm') === undefined || (root.properties.get('org.eclipse.elk.algorithm') as string).endsWith('layered')) {
         result = renderHierarchyLevelLayered(nodes)
-    } else if ((root.properties.get("org.eclipse.elk.algorithm") as string).endsWith('rectpacking')) {
+    } else if ((root.properties.get('org.eclipse.elk.algorithm') as string).endsWith('rectpacking')) {
         result = renderHierarchyLevelRectPacking(nodes)
     } else {
         // Not supported
@@ -49,11 +49,11 @@ export function renderInteractiveLayout(root: KNode): VNode {
  */
 export function renderConstraints(node: KNode): VNode {
     let result = <g></g>
-    const algorithm = (node.parent as KNode).properties.get("org.eclipse.elk.algorithm") as string
+    const algorithm = (node.parent as KNode).properties.get('org.eclipse.elk.algorithm') as string
     if (algorithm === undefined || algorithm.endsWith('layered')) {
         result = renderLayeredConstraint(node)
     } else if (algorithm.endsWith('rectpacking')) {
-        if (node.properties.get("org.eclipse.elk.alg.rectpacking.desiredPosition") !== -1) {
+        if (node.properties.get('org.eclipse.elk.alg.rectpacking.desiredPosition') !== -1) {
             result = renderRectPackConstraint(node)
         }
     } else {

--- a/packages/klighd-interactive/src/interactive-view.tsx
+++ b/packages/klighd-interactive/src/interactive-view.tsx
@@ -30,9 +30,9 @@ export function renderInteractiveLayout(root: KNode): VNode {
     // Filter KNodes
     const nodes = filterKNodes(root.children)
     let result = undefined
-    if (root.properties.algorithm === undefined || root.properties.algorithm.endsWith('layered')) {
+    if (root.properties.get("org.eclipse.elk.algorithm") === undefined || (root.properties.get("org.eclipse.elk.algorithm") as string).endsWith('layered')) {
         result = renderHierarchyLevelLayered(nodes)
-    } else if (root.properties.algorithm.endsWith('rectpacking')) {
+    } else if ((root.properties.get("org.eclipse.elk.algorithm") as string).endsWith('rectpacking')) {
         result = renderHierarchyLevelRectPacking(nodes)
     } else {
         // Not supported
@@ -49,11 +49,11 @@ export function renderInteractiveLayout(root: KNode): VNode {
  */
 export function renderConstraints(node: KNode): VNode {
     let result = <g></g>
-    const algorithm = (node.parent as KNode).properties.algorithm
+    const algorithm = (node.parent as KNode).properties.get("org.eclipse.elk.algorithm") as string
     if (algorithm === undefined || algorithm.endsWith('layered')) {
         result = renderLayeredConstraint(node)
-    } else if (algorithm.endsWith( 'rectpacking')) {
-        if (node.properties.desiredPosition !== -1) {
+    } else if (algorithm.endsWith('rectpacking')) {
+        if (node.properties.get("org.eclipse.elk.alg.rectpacking.desiredPosition") !== -1) {
             result = renderRectPackConstraint(node)
         }
     } else {

--- a/packages/klighd-interactive/src/klighd-interactive-mouselistener.ts
+++ b/packages/klighd-interactive/src/klighd-interactive-mouselistener.ts
@@ -81,12 +81,12 @@ export class KlighdInteractiveMouseListener extends MoveMouseListener {
             targetNode = target.parent
         }
         if (targetNode && targetNode instanceof SNode) {
-            if (((targetNode as KNode).parent as KNode).properties.get('org.eclipse.elk.interactiveLayout')) {
+            if (((targetNode as KNode).parent as KNode).properties['org.eclipse.elk.interactiveLayout']) {
                 this.target = targetNode as KNode
                 // Set layer bounds
                 this.nodes = filterKNodes(this.target.parent.children)
 
-                const algorithm = ((targetNode as KNode).parent as KNode).properties.get('org.eclipse.elk.algorithm') as string
+                const algorithm = ((targetNode as KNode).parent as KNode).properties['org.eclipse.elk.algorithm'] as string
                 // Set algorithm specific data
                 if (algorithm === undefined || algorithm.endsWith('layered')) {
                     this.data.set('layered', getLayers(this.nodes, this.target.direction))
@@ -130,7 +130,7 @@ export class KlighdInteractiveMouseListener extends MoveMouseListener {
             // if a node is moved set properties
             this.target.shadow = false
             let result = super.mouseUp(this.target, event)
-            const algorithm = (this.target.parent as KNode).properties.get('org.eclipse.elk.algorithm') as string
+            const algorithm = (this.target.parent as KNode).properties['org.eclipse.elk.algorithm'] as string
             if (algorithm === undefined || algorithm.endsWith('layered')) {
                 result = [setProperty(this.nodes, this.data.get('layered'), this.target)].concat(super.mouseUp(this.target, event));
             } else if (algorithm.endsWith('rectpacking')) {

--- a/packages/klighd-interactive/src/klighd-interactive-mouselistener.ts
+++ b/packages/klighd-interactive/src/klighd-interactive-mouselistener.ts
@@ -81,12 +81,12 @@ export class KlighdInteractiveMouseListener extends MoveMouseListener {
             targetNode = target.parent
         }
         if (targetNode && targetNode instanceof SNode) {
-            if (((targetNode as KNode).parent as KNode).properties.get("org.eclipse.elk.interactiveLayout")) {
+            if (((targetNode as KNode).parent as KNode).properties.get('org.eclipse.elk.interactiveLayout')) {
                 this.target = targetNode as KNode
                 // Set layer bounds
                 this.nodes = filterKNodes(this.target.parent.children)
 
-                const algorithm = ((targetNode as KNode).parent as KNode).properties.get("org.eclipse.elk.algorithm") as string
+                const algorithm = ((targetNode as KNode).parent as KNode).properties.get('org.eclipse.elk.algorithm') as string
                 // Set algorithm specific data
                 if (algorithm === undefined || algorithm.endsWith('layered')) {
                     this.data.set('layered', getLayers(this.nodes, this.target.direction))
@@ -130,7 +130,7 @@ export class KlighdInteractiveMouseListener extends MoveMouseListener {
             // if a node is moved set properties
             this.target.shadow = false
             let result = super.mouseUp(this.target, event)
-            const algorithm = (this.target.parent as KNode).properties.get("org.eclipse.elk.algorithm") as string
+            const algorithm = (this.target.parent as KNode).properties.get('org.eclipse.elk.algorithm') as string
             if (algorithm === undefined || algorithm.endsWith('layered')) {
                 result = [setProperty(this.nodes, this.data.get('layered'), this.target)].concat(super.mouseUp(this.target, event));
             } else if (algorithm.endsWith('rectpacking')) {

--- a/packages/klighd-interactive/src/klighd-interactive-mouselistener.ts
+++ b/packages/klighd-interactive/src/klighd-interactive-mouselistener.ts
@@ -81,12 +81,12 @@ export class KlighdInteractiveMouseListener extends MoveMouseListener {
             targetNode = target.parent
         }
         if (targetNode && targetNode instanceof SNode) {
-            if (((targetNode as KNode).parent as KNode).properties.interactiveLayout) {
+            if (((targetNode as KNode).parent as KNode).properties.get("org.eclipse.elk.interactiveLayout")) {
                 this.target = targetNode as KNode
                 // Set layer bounds
                 this.nodes = filterKNodes(this.target.parent.children)
 
-                const algorithm = ((targetNode as KNode).parent as KNode).properties.algorithm
+                const algorithm = ((targetNode as KNode).parent as KNode).properties.get("org.eclipse.elk.algorithm") as string
                 // Set algorithm specific data
                 if (algorithm === undefined || algorithm.endsWith('layered')) {
                     this.data.set('layered', getLayers(this.nodes, this.target.direction))
@@ -130,7 +130,7 @@ export class KlighdInteractiveMouseListener extends MoveMouseListener {
             // if a node is moved set properties
             this.target.shadow = false
             let result = super.mouseUp(this.target, event)
-            const algorithm = (this.target.parent as KNode).properties.algorithm
+            const algorithm = (this.target.parent as KNode).properties.get("org.eclipse.elk.algorithm") as string
             if (algorithm === undefined || algorithm.endsWith('layered')) {
                 result = [setProperty(this.nodes, this.data.get('layered'), this.target)].concat(super.mouseUp(this.target, event));
             } else if (algorithm.endsWith('rectpacking')) {

--- a/packages/klighd-interactive/src/layered/constraint-utils.ts
+++ b/packages/klighd-interactive/src/layered/constraint-utils.ts
@@ -71,7 +71,7 @@ export function getLayerOfNode(node: KNode, nodes: KNode[], layers: Layer[], dir
 export function getActualLayer(node: KNode, nodes: KNode[], layerCandidate: number): number {
 
     // Examine all nodes that have a layer Id left or equal to the layerCandidate and that have a layerCons > their layerId
-    const layerConstraintLeftOfCandidate = nodes.filter(n => n.properties.get("org.eclipse.elk.layered.layering.layerId") as number <= layerCandidate && (n.properties.get("org.eclipse.elk.layered.layering.layerChoiceConstraint") as number) > (n.properties.get("org.eclipse.elk.layered.layering.layerId") as number))
+    const layerConstraintLeftOfCandidate = nodes.filter(n => n.properties.get('org.eclipse.elk.layered.layering.layerId') as number <= layerCandidate && (n.properties.get('org.eclipse.elk.layered.layering.layerChoiceConstraint') as number) > (n.properties.get('org.eclipse.elk.layered.layering.layerId') as number))
 
     // In case that there are no such nodes return the layerCandidate
     if (layerConstraintLeftOfCandidate.length === 0) {
@@ -84,7 +84,7 @@ export function getActualLayer(node: KNode, nodes: KNode[], layerCandidate: numb
     let nodeWithMaxCons = null
     let maxCons = -1
     for (const n of layerConstraintLeftOfCandidate) {
-        const layerConstraint = n.properties.get("org.eclipse.elk.layered.layering.layerChoiceConstraint") as number
+        const layerConstraint = n.properties.get('org.eclipse.elk.layered.layering.layerChoiceConstraint') as number
         if (layerConstraint > maxCons) {
             nodeWithMaxCons = n
             maxCons = layerConstraint
@@ -92,7 +92,7 @@ export function getActualLayer(node: KNode, nodes: KNode[], layerCandidate: numb
     }
 
     if (nodeWithMaxCons !== null) {
-        const idDiff = layerCandidate - (nodeWithMaxCons.properties.get("org.eclipse.elk.layered.layering.layerId") as number)
+        const idDiff = layerCandidate - (nodeWithMaxCons.properties.get('org.eclipse.elk.layered.layering.layerId') as number)
         return maxCons + idDiff
     }
 
@@ -112,9 +112,9 @@ export function getActualTargetIndex(targetIndex: number, alreadyInLayer: boolea
         // than its position ID
         const upperIndex = localTargetIndex - 1
         const upperNeighbor = layerNodes[upperIndex]
-        const posConsOfUpper = upperNeighbor.properties.get("org.eclipse.elk.layered.crossingMinimization.positionChoiceConstraint") as number
+        const posConsOfUpper = upperNeighbor.properties.get('org.eclipse.elk.layered.crossingMinimization.positionChoiceConstraint') as number
         if (posConsOfUpper > upperIndex) {
-            if (alreadyInLayer && upperNeighbor.properties.get("org.eclipse.elk.layered.crossingMinimization.positionId") === localTargetIndex) {
+            if (alreadyInLayer && upperNeighbor.properties.get('org.eclipse.elk.layered.crossingMinimization.positionId') === localTargetIndex) {
                 localTargetIndex = posConsOfUpper
             } else {
                 localTargetIndex = posConsOfUpper + 1
@@ -130,7 +130,7 @@ export function getActualTargetIndex(targetIndex: number, alreadyInLayer: boolea
  */
 export function getLayers(nodes: KNode[], direction: Direction): Layer[] {
     // All nodes within one hierarchy level have the same direction
-    nodes.sort((a, b) => (a.properties.get("org.eclipse.elk.layered.layering.layerId") as number) - (b.properties.get("org.eclipse.elk.layered.layering.layerId") as number))
+    nodes.sort((a, b) => (a.properties.get('org.eclipse.elk.layered.layering.layerId') as number) - (b.properties.get('org.eclipse.elk.layered.layering.layerId') as number))
     const layers = []
     let layer = 0
     // Begin coordinate of layer, depending of on the layout direction this might be a x or y coordinate
@@ -142,7 +142,7 @@ export function getLayers(nodes: KNode[], direction: Direction): Layer[] {
     // calculate bounds of the layers
     for (let i = 0; i < nodes.length; i++) {
         const node = nodes[i]
-        if (node.properties.get("org.eclipse.elk.layered.layering.layerId") !== layer) {
+        if (node.properties.get('org.eclipse.elk.layered.layering.layerId') !== layer) {
             // node is in the next layer
             layers[layer] = new Layer(beginCoordinate, endCoordinate, beginCoordinate + (endCoordinate - beginCoordinate) / 2, direction)
             beginCoordinate = (direction === Direction.UNDEFINED || direction === Direction.RIGHT || direction === Direction.DOWN) ? Number.MAX_VALUE : Number.MIN_VALUE
@@ -275,7 +275,7 @@ export function getLayers(nodes: KNode[], direction: Direction): Layer[] {
 export function getNodesOfLayer(layer: number, nodes: KNode[]): KNode[] {
     const nodesOfLayer: KNode[] = []
     for (const node of nodes) {
-        if (node.properties.get("org.eclipse.elk.layered.layering.layerId") === layer) {
+        if (node.properties.get('org.eclipse.elk.layered.layering.layerId') === layer) {
             nodesOfLayer[nodesOfLayer.length] = node
         }
     }
@@ -325,7 +325,7 @@ export function isLayerForbidden(node: KNode, layer: number): boolean {
 
     // check the connected nodes for layer constraints
     for (const node of connectedNodes) {
-        if (node.properties.get("org.eclipse.elk.layered.layering.layerId") === layer && node.properties.get("org.eclipse.elk.layered.layering.layerChoiceConstraint") !== -1) {
+        if (node.properties.get('org.eclipse.elk.layered.layering.layerId') === layer && node.properties.get('org.eclipse.elk.layered.layering.layerChoiceConstraint') !== -1) {
             // layer is forbidden for the given node
             return true
         }
@@ -369,7 +369,7 @@ export function setProperty(nodes: KNode[], layers: Layer[], target: SModelEleme
     if (forbidden) {
         // If layer is forbidden just refresh
         return RefreshDiagramAction.create()
-    } else if (targetNode.properties.get("org.eclipse.elk.layered.layering.layerId") !== layerOfTarget) {
+    } else if (targetNode.properties.get('org.eclipse.elk.layered.layering.layerId') !== layerOfTarget) {
         // layer constraint should only be set if the layer index changed
         if (shouldOnlyLCBeSet(targetNode, layers, direction)) {
             // only the layer constraint should be set
@@ -391,7 +391,7 @@ export function setProperty(nodes: KNode[], layers: Layer[], target: SModelEleme
     } else {
 
         // position constraint should only be set if the position of the node changed
-        if (targetNode.properties.get("org.eclipse.elk.layered.crossingMinimization.positionId") !== positionOfTarget) {
+        if (targetNode.properties.get('org.eclipse.elk.layered.crossingMinimization.positionId') !== positionOfTarget) {
             // set the position Constraint
             return SetPositionConstraintAction.create({
                 id: targetNode.id,

--- a/packages/klighd-interactive/src/layered/constraint-utils.ts
+++ b/packages/klighd-interactive/src/layered/constraint-utils.ts
@@ -326,7 +326,7 @@ export function isLayerForbidden(node: KNode, layer: number): boolean {
 
     // check the connected nodes for layer constraints
     for (const node of connectedNodes) {
-        if (node.properties['org.eclipse.elk.layered.layering.layerId'] === layer && node.properties['org.eclipse.elk.layered.layering.layerChoiceConstraint'] !== -1) {
+        if (node.properties['org.eclipse.elk.layered.layering.layerId'] === layer && node.properties['org.eclipse.elk.layered.layering.layerChoiceConstraint'] !== -1 && node.properties['org.eclipse.elk.layered.layering.layerChoiceConstraint'] !== undefined) {
             // layer is forbidden for the given node
             return true
         }

--- a/packages/klighd-interactive/src/layered/constraint-utils.ts
+++ b/packages/klighd-interactive/src/layered/constraint-utils.ts
@@ -71,7 +71,8 @@ export function getLayerOfNode(node: KNode, nodes: KNode[], layers: Layer[], dir
 export function getActualLayer(node: KNode, nodes: KNode[], layerCandidate: number): number {
 
     // Examine all nodes that have a layer Id left or equal to the layerCandidate and that have a layerCons > their layerId
-    const layerConstraintLeftOfCandidate = nodes.filter(n => n.properties['org.eclipse.elk.layered.layering.layerId'] as number <= layerCandidate && (n.properties['org.eclipse.elk.layered.layering.layerChoiceConstraint'] as number) > (n.properties['org.eclipse.elk.layered.layering.layerId'] as number))
+    const layerConstraintLeftOfCandidate = nodes.filter(n => n.properties['org.eclipse.elk.layered.layering.layerId'] as number <= layerCandidate
+        && (n.properties['org.eclipse.elk.layered.layering.layerChoiceConstraint'] as number) > (n.properties['org.eclipse.elk.layered.layering.layerId'] as number))
 
     // In case that there are no such nodes return the layerCandidate
     if (layerConstraintLeftOfCandidate.length === 0) {

--- a/packages/klighd-interactive/src/layered/constraint-utils.ts
+++ b/packages/klighd-interactive/src/layered/constraint-utils.ts
@@ -326,7 +326,9 @@ export function isLayerForbidden(node: KNode, layer: number): boolean {
 
     // check the connected nodes for layer constraints
     for (const node of connectedNodes) {
-        if (node.properties['org.eclipse.elk.layered.layering.layerId'] === layer && node.properties['org.eclipse.elk.layered.layering.layerChoiceConstraint'] !== -1 && node.properties['org.eclipse.elk.layered.layering.layerChoiceConstraint'] !== undefined) {
+        if (node.properties['org.eclipse.elk.layered.layering.layerId'] === layer
+            && node.properties['org.eclipse.elk.layered.layering.layerChoiceConstraint'] !== -1
+            && node.properties['org.eclipse.elk.layered.layering.layerChoiceConstraint'] !== undefined) {
             // layer is forbidden for the given node
             return true
         }

--- a/packages/klighd-interactive/src/layered/constraint-utils.ts
+++ b/packages/klighd-interactive/src/layered/constraint-utils.ts
@@ -71,7 +71,7 @@ export function getLayerOfNode(node: KNode, nodes: KNode[], layers: Layer[], dir
 export function getActualLayer(node: KNode, nodes: KNode[], layerCandidate: number): number {
 
     // Examine all nodes that have a layer Id left or equal to the layerCandidate and that have a layerCons > their layerId
-    const layerConstraintLeftOfCandidate = nodes.filter(n => n.properties.get('org.eclipse.elk.layered.layering.layerId') as number <= layerCandidate && (n.properties.get('org.eclipse.elk.layered.layering.layerChoiceConstraint') as number) > (n.properties.get('org.eclipse.elk.layered.layering.layerId') as number))
+    const layerConstraintLeftOfCandidate = nodes.filter(n => n.properties['org.eclipse.elk.layered.layering.layerId'] as number <= layerCandidate && (n.properties['org.eclipse.elk.layered.layering.layerChoiceConstraint'] as number) > (n.properties['org.eclipse.elk.layered.layering.layerId'] as number))
 
     // In case that there are no such nodes return the layerCandidate
     if (layerConstraintLeftOfCandidate.length === 0) {
@@ -84,7 +84,7 @@ export function getActualLayer(node: KNode, nodes: KNode[], layerCandidate: numb
     let nodeWithMaxCons = null
     let maxCons = -1
     for (const n of layerConstraintLeftOfCandidate) {
-        const layerConstraint = n.properties.get('org.eclipse.elk.layered.layering.layerChoiceConstraint') as number
+        const layerConstraint = n.properties['org.eclipse.elk.layered.layering.layerChoiceConstraint'] as number
         if (layerConstraint > maxCons) {
             nodeWithMaxCons = n
             maxCons = layerConstraint
@@ -92,7 +92,7 @@ export function getActualLayer(node: KNode, nodes: KNode[], layerCandidate: numb
     }
 
     if (nodeWithMaxCons !== null) {
-        const idDiff = layerCandidate - (nodeWithMaxCons.properties.get('org.eclipse.elk.layered.layering.layerId') as number)
+        const idDiff = layerCandidate - (nodeWithMaxCons.properties['org.eclipse.elk.layered.layering.layerId'] as number)
         return maxCons + idDiff
     }
 
@@ -112,9 +112,9 @@ export function getActualTargetIndex(targetIndex: number, alreadyInLayer: boolea
         // than its position ID
         const upperIndex = localTargetIndex - 1
         const upperNeighbor = layerNodes[upperIndex]
-        const posConsOfUpper = upperNeighbor.properties.get('org.eclipse.elk.layered.crossingMinimization.positionChoiceConstraint') as number
+        const posConsOfUpper = upperNeighbor.properties['org.eclipse.elk.layered.crossingMinimization.positionChoiceConstraint'] as number
         if (posConsOfUpper > upperIndex) {
-            if (alreadyInLayer && upperNeighbor.properties.get('org.eclipse.elk.layered.crossingMinimization.positionId') === localTargetIndex) {
+            if (alreadyInLayer && upperNeighbor.properties['org.eclipse.elk.layered.crossingMinimization.positionId'] === localTargetIndex) {
                 localTargetIndex = posConsOfUpper
             } else {
                 localTargetIndex = posConsOfUpper + 1
@@ -130,7 +130,7 @@ export function getActualTargetIndex(targetIndex: number, alreadyInLayer: boolea
  */
 export function getLayers(nodes: KNode[], direction: Direction): Layer[] {
     // All nodes within one hierarchy level have the same direction
-    nodes.sort((a, b) => (a.properties.get('org.eclipse.elk.layered.layering.layerId') as number) - (b.properties.get('org.eclipse.elk.layered.layering.layerId') as number))
+    nodes.sort((a, b) => (a.properties['org.eclipse.elk.layered.layering.layerId'] as number) - (b.properties['org.eclipse.elk.layered.layering.layerId'] as number))
     const layers = []
     let layer = 0
     // Begin coordinate of layer, depending of on the layout direction this might be a x or y coordinate
@@ -142,7 +142,7 @@ export function getLayers(nodes: KNode[], direction: Direction): Layer[] {
     // calculate bounds of the layers
     for (let i = 0; i < nodes.length; i++) {
         const node = nodes[i]
-        if (node.properties.get('org.eclipse.elk.layered.layering.layerId') !== layer) {
+        if (node.properties['org.eclipse.elk.layered.layering.layerId'] !== layer) {
             // node is in the next layer
             layers[layer] = new Layer(beginCoordinate, endCoordinate, beginCoordinate + (endCoordinate - beginCoordinate) / 2, direction)
             beginCoordinate = (direction === Direction.UNDEFINED || direction === Direction.RIGHT || direction === Direction.DOWN) ? Number.MAX_VALUE : Number.MIN_VALUE
@@ -275,7 +275,7 @@ export function getLayers(nodes: KNode[], direction: Direction): Layer[] {
 export function getNodesOfLayer(layer: number, nodes: KNode[]): KNode[] {
     const nodesOfLayer: KNode[] = []
     for (const node of nodes) {
-        if (node.properties.get('org.eclipse.elk.layered.layering.layerId') === layer) {
+        if (node.properties['org.eclipse.elk.layered.layering.layerId'] === layer) {
             nodesOfLayer[nodesOfLayer.length] = node
         }
     }
@@ -325,7 +325,7 @@ export function isLayerForbidden(node: KNode, layer: number): boolean {
 
     // check the connected nodes for layer constraints
     for (const node of connectedNodes) {
-        if (node.properties.get('org.eclipse.elk.layered.layering.layerId') === layer && node.properties.get('org.eclipse.elk.layered.layering.layerChoiceConstraint') !== -1) {
+        if (node.properties['org.eclipse.elk.layered.layering.layerId'] === layer && node.properties['org.eclipse.elk.layered.layering.layerChoiceConstraint'] !== -1) {
             // layer is forbidden for the given node
             return true
         }
@@ -369,7 +369,7 @@ export function setProperty(nodes: KNode[], layers: Layer[], target: SModelEleme
     if (forbidden) {
         // If layer is forbidden just refresh
         return RefreshDiagramAction.create()
-    } else if (targetNode.properties.get('org.eclipse.elk.layered.layering.layerId') !== layerOfTarget) {
+    } else if (targetNode.properties['org.eclipse.elk.layered.layering.layerId'] !== layerOfTarget) {
         // layer constraint should only be set if the layer index changed
         if (shouldOnlyLCBeSet(targetNode, layers, direction)) {
             // only the layer constraint should be set
@@ -391,7 +391,7 @@ export function setProperty(nodes: KNode[], layers: Layer[], target: SModelEleme
     } else {
 
         // position constraint should only be set if the position of the node changed
-        if (targetNode.properties.get('org.eclipse.elk.layered.crossingMinimization.positionId') !== positionOfTarget) {
+        if (targetNode.properties['org.eclipse.elk.layered.crossingMinimization.positionId'] !== positionOfTarget) {
             // set the position Constraint
             return SetPositionConstraintAction.create({
                 id: targetNode.id,

--- a/packages/klighd-interactive/src/layered/layered-interactive-view.tsx
+++ b/packages/klighd-interactive/src/layered/layered-interactive-view.tsx
@@ -45,7 +45,7 @@ export function renderHierarchyLevel(nodes: KNode[]): VNode {
         // let globalEndCoordinate = layers[layers.length - 1].end
 
         // determines whether only the layer constraint will be set when the node is released
-        const onlyLC = shouldOnlyLCBeSet(selNode, layers, direction) && selNode.properties.layerId !== currentLayer
+        const onlyLC = shouldOnlyLCBeSet(selNode, layers, direction) && selNode.properties.get("org.eclipse.elk.layered.layering.layerId") !== currentLayer
 
         // create layers
         let result = <g></g>
@@ -79,7 +79,7 @@ export function renderHierarchyLevel(nodes: KNode[]): VNode {
             return <g>{result}{renderPositions(currentLayer, nodes, layers, forbidden, direction)}</g>
         } else {
             // Add available positions
-    // @ts-ignore
+            // @ts-ignore
             return result
         }
     }
@@ -108,7 +108,7 @@ export function renderPositions(current: number, nodes: KNode[], layers: Layer[]
     // position of selected node
     const curPos = getPositionInLayer(layerNodes, target)
 
-    layerNodes.sort((a, b) => a.properties.positionId - b.properties.positionId)
+    layerNodes.sort((a, b) => (a.properties.get("org.eclipse.elk.layered.crossingMinimization.positionId") as number) - (b.properties.get("org.eclipse.elk.layered.crossingMinimization.positionId") as number))
     if (layerNodes.length > 0) {
         let result = <g></g>
         // mid of the current layer
@@ -258,8 +258,8 @@ export function renderLayeredConstraint(node: KNode): VNode {
     const x = node.size.width
     const y = 0
     const constraintOffset = 2
-    const positionConstraint = node.properties.positionConstraint
-    const layerConstraint = node.properties.layerConstraint
+    const positionConstraint = node.properties.get("org.eclipse.elk.layered.crossingMinimization.positionChoiceConstraint") as number
+    const layerConstraint = node.properties.get("org.eclipse.elk.layered.layering.layerChoiceConstraint")
     if (layerConstraint !== -1 && positionConstraint !== -1) {
         // layer and position Constraint are set
         result = <g>{renderLock(x, y)}</g>

--- a/packages/klighd-interactive/src/layered/layered-interactive-view.tsx
+++ b/packages/klighd-interactive/src/layered/layered-interactive-view.tsx
@@ -260,13 +260,13 @@ export function renderLayeredConstraint(node: KNode): VNode {
     const constraintOffset = 2
     const positionConstraint = node.properties['org.eclipse.elk.layered.crossingMinimization.positionChoiceConstraint'] as number
     const layerConstraint = node.properties['org.eclipse.elk.layered.layering.layerChoiceConstraint']
-    if (layerConstraint !== -1 && positionConstraint !== -1) {
+    if (layerConstraint !== -1 && positionConstraint !== -1 && layerConstraint !== undefined && positionConstraint !== undefined) {
         // layer and position Constraint are set
         result = <g>{renderLock(x, y)}</g>
-    } else if (layerConstraint !== -1) {
+    } else if (layerConstraint !== -1 && layerConstraint !== undefined) {
         // only layer Constraint is set
         result = <g>{renderLayerConstraint(x + constraintOffset, y - constraintOffset, node.direction)}</g>
-    } else if (positionConstraint !== -1) {
+    } else if (positionConstraint !== -1 && positionConstraint !== undefined) {
         // only position Constraint is set
         result = <g>{renderPositionConstraint(x + constraintOffset, y - constraintOffset, node.direction)}</g>
     }

--- a/packages/klighd-interactive/src/layered/layered-interactive-view.tsx
+++ b/packages/klighd-interactive/src/layered/layered-interactive-view.tsx
@@ -45,7 +45,7 @@ export function renderHierarchyLevel(nodes: KNode[]): VNode {
         // let globalEndCoordinate = layers[layers.length - 1].end
 
         // determines whether only the layer constraint will be set when the node is released
-        const onlyLC = shouldOnlyLCBeSet(selNode, layers, direction) && selNode.properties.get('org.eclipse.elk.layered.layering.layerId') !== currentLayer
+        const onlyLC = shouldOnlyLCBeSet(selNode, layers, direction) && selNode.properties['org.eclipse.elk.layered.layering.layerId'] !== currentLayer
 
         // create layers
         let result = <g></g>
@@ -108,7 +108,7 @@ export function renderPositions(current: number, nodes: KNode[], layers: Layer[]
     // position of selected node
     const curPos = getPositionInLayer(layerNodes, target)
 
-    layerNodes.sort((a, b) => (a.properties.get('org.eclipse.elk.layered.crossingMinimization.positionId') as number) - (b.properties.get('org.eclipse.elk.layered.crossingMinimization.positionId') as number))
+    layerNodes.sort((a, b) => (a.properties['org.eclipse.elk.layered.crossingMinimization.positionId'] as number) - (b.properties['org.eclipse.elk.layered.crossingMinimization.positionId'] as number))
     if (layerNodes.length > 0) {
         let result = <g></g>
         // mid of the current layer
@@ -258,8 +258,8 @@ export function renderLayeredConstraint(node: KNode): VNode {
     const x = node.size.width
     const y = 0
     const constraintOffset = 2
-    const positionConstraint = node.properties.get('org.eclipse.elk.layered.crossingMinimization.positionChoiceConstraint') as number
-    const layerConstraint = node.properties.get('org.eclipse.elk.layered.layering.layerChoiceConstraint')
+    const positionConstraint = node.properties['org.eclipse.elk.layered.crossingMinimization.positionChoiceConstraint'] as number
+    const layerConstraint = node.properties['org.eclipse.elk.layered.layering.layerChoiceConstraint']
     if (layerConstraint !== -1 && positionConstraint !== -1) {
         // layer and position Constraint are set
         result = <g>{renderLock(x, y)}</g>

--- a/packages/klighd-interactive/src/layered/layered-interactive-view.tsx
+++ b/packages/klighd-interactive/src/layered/layered-interactive-view.tsx
@@ -45,7 +45,7 @@ export function renderHierarchyLevel(nodes: KNode[]): VNode {
         // let globalEndCoordinate = layers[layers.length - 1].end
 
         // determines whether only the layer constraint will be set when the node is released
-        const onlyLC = shouldOnlyLCBeSet(selNode, layers, direction) && selNode.properties.get("org.eclipse.elk.layered.layering.layerId") !== currentLayer
+        const onlyLC = shouldOnlyLCBeSet(selNode, layers, direction) && selNode.properties.get('org.eclipse.elk.layered.layering.layerId') !== currentLayer
 
         // create layers
         let result = <g></g>
@@ -108,7 +108,7 @@ export function renderPositions(current: number, nodes: KNode[], layers: Layer[]
     // position of selected node
     const curPos = getPositionInLayer(layerNodes, target)
 
-    layerNodes.sort((a, b) => (a.properties.get("org.eclipse.elk.layered.crossingMinimization.positionId") as number) - (b.properties.get("org.eclipse.elk.layered.crossingMinimization.positionId") as number))
+    layerNodes.sort((a, b) => (a.properties.get('org.eclipse.elk.layered.crossingMinimization.positionId') as number) - (b.properties.get('org.eclipse.elk.layered.crossingMinimization.positionId') as number))
     if (layerNodes.length > 0) {
         let result = <g></g>
         // mid of the current layer
@@ -258,8 +258,8 @@ export function renderLayeredConstraint(node: KNode): VNode {
     const x = node.size.width
     const y = 0
     const constraintOffset = 2
-    const positionConstraint = node.properties.get("org.eclipse.elk.layered.crossingMinimization.positionChoiceConstraint") as number
-    const layerConstraint = node.properties.get("org.eclipse.elk.layered.layering.layerChoiceConstraint")
+    const positionConstraint = node.properties.get('org.eclipse.elk.layered.crossingMinimization.positionChoiceConstraint') as number
+    const layerConstraint = node.properties.get('org.eclipse.elk.layered.layering.layerChoiceConstraint')
     if (layerConstraint !== -1 && positionConstraint !== -1) {
         // layer and position Constraint are set
         result = <g>{renderLock(x, y)}</g>

--- a/packages/klighd-interactive/src/rect-packing/constraint-util.ts
+++ b/packages/klighd-interactive/src/rect-packing/constraint-util.ts
@@ -43,13 +43,13 @@ export function setGenerateRectPackAction(nodes: KNode[], target: KNode, parent:
             const highY = boundsInWindow.y + boundsInWindow.height
             if (event.pageX > lowX && event.pageX < highX
                 && event.pageY > lowY && event.pageY < highY) {
-                let actualPosition = node.properties.get("org.eclipse.elk.rectPacking.currentPosition") as number
-                if (node.properties.get("org.eclipse.elk.alg.rectpacking.desiredPosition") !== -1) {
-                    actualPosition = node.properties.get("org.eclipse.elk.alg.rectpacking.desiredPosition") as number
+                let actualPosition = node.properties.get('org.eclipse.elk.rectPacking.currentPosition') as number
+                if (node.properties.get('org.eclipse.elk.alg.rectpacking.desiredPosition') !== -1) {
+                    actualPosition = node.properties.get('org.eclipse.elk.alg.rectpacking.desiredPosition') as number
                 }
-                let actualTargetPosition = target.properties.get("org.eclipse.elk.rectPacking.currentPosition") as number
-                if (node.properties.get("org.eclipse.elk.alg.rectpacking.desiredPosition") !== -1) {
-                    actualTargetPosition = target.properties.get("org.eclipse.elk.alg.rectpacking.desiredPosition") as number
+                let actualTargetPosition = target.properties.get('org.eclipse.elk.rectPacking.currentPosition') as number
+                if (node.properties.get('org.eclipse.elk.alg.rectpacking.desiredPosition') !== -1) {
+                    actualTargetPosition = target.properties.get('org.eclipse.elk.alg.rectpacking.desiredPosition') as number
                 }
                 if (actualPosition !== actualTargetPosition && actualPosition !== -1) {
                     result = RectPackSetPositionConstraintAction.create({
@@ -84,7 +84,7 @@ export function setGenerateRectPackAction(nodes: KNode[], target: KNode, parent:
         const aspectRatio = (maxX - x) / (maxY - y)
 
         // If changed update aspect ratio.
-        if (parent && parent.properties.get("org.eclipse.elk.rectPacking.aspectRatio") !== aspectRatio) {
+        if (parent && parent.properties.get('org.eclipse.elk.rectPacking.aspectRatio') !== aspectRatio) {
             return SetAspectRatioAction.create({
                 id: parent.id,
                 aspectRatio: aspectRatio

--- a/packages/klighd-interactive/src/rect-packing/constraint-util.ts
+++ b/packages/klighd-interactive/src/rect-packing/constraint-util.ts
@@ -43,13 +43,13 @@ export function setGenerateRectPackAction(nodes: KNode[], target: KNode, parent:
             const highY = boundsInWindow.y + boundsInWindow.height
             if (event.pageX > lowX && event.pageX < highX
                 && event.pageY > lowY && event.pageY < highY) {
-                let actualPosition = node.properties.get('org.eclipse.elk.rectPacking.currentPosition') as number
-                if (node.properties.get('org.eclipse.elk.alg.rectpacking.desiredPosition') !== -1) {
-                    actualPosition = node.properties.get('org.eclipse.elk.alg.rectpacking.desiredPosition') as number
+                let actualPosition = node.properties['org.eclipse.elk.rectPacking.currentPosition'] as number
+                if (node.properties['org.eclipse.elk.alg.rectpacking.desiredPosition'] !== -1) {
+                    actualPosition = node.properties['org.eclipse.elk.alg.rectpacking.desiredPosition'] as number
                 }
-                let actualTargetPosition = target.properties.get('org.eclipse.elk.rectPacking.currentPosition') as number
-                if (node.properties.get('org.eclipse.elk.alg.rectpacking.desiredPosition') !== -1) {
-                    actualTargetPosition = target.properties.get('org.eclipse.elk.alg.rectpacking.desiredPosition') as number
+                let actualTargetPosition = target.properties['org.eclipse.elk.rectPacking.currentPosition'] as number
+                if (node.properties['org.eclipse.elk.alg.rectpacking.desiredPosition'] !== -1) {
+                    actualTargetPosition = target.properties['org.eclipse.elk.alg.rectpacking.desiredPosition'] as number
                 }
                 if (actualPosition !== actualTargetPosition && actualPosition !== -1) {
                     result = RectPackSetPositionConstraintAction.create({
@@ -84,7 +84,7 @@ export function setGenerateRectPackAction(nodes: KNode[], target: KNode, parent:
         const aspectRatio = (maxX - x) / (maxY - y)
 
         // If changed update aspect ratio.
-        if (parent && parent.properties.get('org.eclipse.elk.rectPacking.aspectRatio') !== aspectRatio) {
+        if (parent && parent.properties['org.eclipse.elk.rectPacking.aspectRatio'] !== aspectRatio) {
             return SetAspectRatioAction.create({
                 id: parent.id,
                 aspectRatio: aspectRatio

--- a/packages/klighd-interactive/src/rect-packing/constraint-util.ts
+++ b/packages/klighd-interactive/src/rect-packing/constraint-util.ts
@@ -43,23 +43,23 @@ export function setGenerateRectPackAction(nodes: KNode[], target: KNode, parent:
             const highY = boundsInWindow.y + boundsInWindow.height
             if (event.pageX > lowX && event.pageX < highX
                 && event.pageY > lowY && event.pageY < highY) {
-                    let actualPosition = node.properties.currentPosition
-                    if (node.properties.desiredPosition !== -1) {
-                        actualPosition = node.properties.desiredPosition
-                    }
-                    let actualTargetPosition = target.properties.currentPosition
-                    if (node.properties.desiredPosition !== -1) {
-                        actualTargetPosition = target.properties.desiredPosition
-                    }
-                    if (actualPosition !== actualTargetPosition && actualPosition !== -1) {
-                        result = RectPackSetPositionConstraintAction.create({
-                            id: target.id, order: actualPosition
-                        })
-                    }
+                let actualPosition = node.properties.get("org.eclipse.elk.rectPacking.currentPosition") as number
+                if (node.properties.get("org.eclipse.elk.alg.rectpacking.desiredPosition") !== -1) {
+                    actualPosition = node.properties.get("org.eclipse.elk.alg.rectpacking.desiredPosition") as number
                 }
+                let actualTargetPosition = target.properties.get("org.eclipse.elk.rectPacking.currentPosition") as number
+                if (node.properties.get("org.eclipse.elk.alg.rectpacking.desiredPosition") !== -1) {
+                    actualTargetPosition = target.properties.get("org.eclipse.elk.alg.rectpacking.desiredPosition") as number
+                }
+                if (actualPosition !== actualTargetPosition && actualPosition !== -1) {
+                    result = RectPackSetPositionConstraintAction.create({
+                        id: target.id, order: actualPosition
+                    })
+                }
+            }
         }
     });
-    if (result.kind ===  RefreshDiagramAction.KIND) {
+    if (result.kind === RefreshDiagramAction.KIND) {
         // Case node should not be swapped.
 
         // Calculate aspect ratio.
@@ -84,7 +84,7 @@ export function setGenerateRectPackAction(nodes: KNode[], target: KNode, parent:
         const aspectRatio = (maxX - x) / (maxY - y)
 
         // If changed update aspect ratio.
-        if (parent && parent.properties.aspectRatio !== aspectRatio) {
+        if (parent && parent.properties.get("org.eclipse.elk.rectPacking.aspectRatio") !== aspectRatio) {
             return SetAspectRatioAction.create({
                 id: parent.id,
                 aspectRatio: aspectRatio


### PR DESCRIPTION
This changes the way elk properties are accessed by the client.
Instead of the NodeProperties class, properties are now a map<string, unknown>, where the key is the the fully qualified name such as "org.eclipse.elk.algorithm"
Because the property types are now unknown, they have to be explicitly cast by the developer meaning the developer has to know the type of the property. Currently all the used properties are primitive types, but more complex types also exist and may need to be dealt with nicely. There may be some more checks necessary to ensure non-existent properties aren't being accessed, but I haven't found any such cases yet. 

[KGraphMappingUtil](https://github.com/kieler/KLighD/blob/72d79588917b5ef7c0e7b970c380d1584dd97419/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/utils/KGraphMappingUtil.xtend#L134) shows how the properties are being set in KlighD. This needs to be improved a bit and the duplicate properties being set in KGraphDiagramGenerator still need to be removed.