### PR TITLE
Fix multiline label position calculation.

### DIFF
--- a/packages/klighd-core/src/views-rendering.tsx
+++ b/packages/klighd-core/src/views-rendering.tsx
@@ -484,6 +484,17 @@ export function renderKText(rendering: KText,
         const calculatedTextLineWidths = rendering.calculatedTextLineWidths
         const calculatedTextLineHeights = rendering.calculatedTextLineHeights
         let currentY = boundsAndTransformation.bounds.y ? boundsAndTransformation.bounds.y : 0
+
+        // Since the text is centered the start position has to be calculated based on the existing line heights.
+        if (calculatedTextLineHeights) {
+            for (let i = 0; i < lines.length / 2.0 - 1; i++) {
+                currentY -= calculatedTextLineHeights[i]
+            }
+            if (!(lines.length % 2)) {
+                currentY -= calculatedTextLineHeights[lines.length / 2] / 2
+            }
+        }
+
         if (rendering.calculatedTextLineWidths) {
             attrs.lengthAdjust = 'spacingAndGlyphs'
         }


### PR DESCRIPTION
Since text is vertically centered one has to calculate the start y coordinate by taking the width of the lines up to the middle line into account.