### PR TITLE
fixed klighd action execution to not care about selectability, but for action defintion as in its Piccolo counterpart.

### DIFF
--- a/packages/klighd-core/src/skgraph-models.ts
+++ b/packages/klighd-core/src/skgraph-models.ts
@@ -3,7 +3,7 @@
  *
  * http://rtsys.informatik.uni-kiel.de/kieler
  *
- * Copyright 2019, 2020, 2021 by
+ * Copyright 2019-2022 by
  * + Kiel University
  *   + Department of Computer Science
  *     + Real-Time and Embedded Systems Group
@@ -692,6 +692,18 @@ export function isContainerRendering(test: KGraphData): test is KContainerRender
         || type === K_SPLINE
         || type === K_RECTANGLE
         || type === K_ROUNDED_RECTANGLE
+}
+
+/**
+ * Returns if the given parameter is a KPolyline.
+ * @param test The potential KPolyline.
+ */
+export function isPolyline(test: KGraphData): test is KPolyline {
+    const type = test.type
+    return  type === K_POLYLINE
+        || type === K_POLYGON
+        || type === K_ROUNDED_BENDS_POLYLINE
+        || type === K_SPLINE
 }
 
 /**

--- a/packages/klighd-core/src/skgraph-utils.ts
+++ b/packages/klighd-core/src/skgraph-utils.ts
@@ -14,39 +14,70 @@
  *
  * SPDX-License-Identifier: EPL-2.0
 */
-import { isContainerRendering, isRendering, KPolyline, KRendering, K_POLYLINE, K_RENDERING_REF, SKGraphElement } from './skgraph-models'
+import { isContainerRendering, isPolyline, isRendering, KPolyline, KRendering, K_POLYLINE, K_RENDERING_REF, SKGraphElement } from './skgraph-models'
 
 /**
  * Returns the SVG element in the DOM that represents the topmost KRendering in the hierarchy.
- * If the element should be selected but is not selectable, the next selectable element in the hierarchy will be chosen.
+ * If an action should be triggered on the element, bubble up through the rendering hierarchy until the first actionable rendering..
  * @param target The graph element the event is triggered on.
  * @param element The topmost SVG element clicked.
- * @param select Optional parameter to search for selectable renderings only. Defaults to false.
+ * @param actionable Optional parameter to search for actionable renderings only. Defaults to false.
  */
-export function getSemanticElement(target: SKGraphElement, element: EventTarget | null, select = false): SVGElement | undefined {
+export function getSemanticElement(target: SKGraphElement, element: EventTarget | null, actionable = false): SVGElement | undefined {
     if (!(element instanceof SVGElement)) {
         return undefined
     }
     let currentElement: Element | null = element
     let semanticElement = undefined
     while (semanticElement === undefined && currentElement instanceof SVGElement) {
-        // If the rendering is configured to be not selectable, do not select it.
-        let renderingSelectable = true
-        if (currentElement.id !== '' && select) {
+        // Check if the rendering has an action.
+        let renderingHasAction = true
+        if (currentElement.id !== '' && actionable) {
             const rendering = findRendering(target, currentElement.id)
-            if (rendering?.properties['de.cau.cs.kieler.klighd.suppressSelectability'] === true) {
-                renderingSelectable = false
+            if (!rendering) {
+                // If no rendering for this ID exists, we have gone too far up to the next graph element. Skip from here.
+                return undefined
+            }
+            if (!hasAction(rendering)) {
+                renderingHasAction = false
             }
         }
         // Choose this element if it is a defined element with an ID.
-        // Also only use this if selection implies it is selectable (select => renderingSelectable)
-        if (currentElement.id !== '' && (!select || renderingSelectable)) {
+        // Also only use this if there is an action and we look for an actionable rendering (action => renderingHasAction)
+        if (currentElement.id !== '' && (!actionable || renderingHasAction)) {
             semanticElement = currentElement
         } else {
             currentElement = currentElement.parentElement
         }
     }
     return semanticElement
+}
+
+/**
+ * Returns if there is a KLighD action defined on the given rendering that needs to be handled.
+ * 
+ * @param rendering the rendering that may define an action to be executed.
+ * @param includeChildren if this should also search for actions in any of the rendering's children.
+ *   Defaults to false.
+ * @returns if there is at least one action for this rendering.
+ */
+ export function hasAction(rendering: KRendering, includeChildren = false): boolean {
+    if (rendering.actions && rendering.actions.length !== 0) {
+        return true
+    }
+    if (includeChildren && isContainerRendering(rendering)) {
+        for (const child of rendering.children) {
+            if (hasAction(child, includeChildren)) {
+                return true
+            }
+        }
+        if (isPolyline(rendering)) {
+            if (hasAction(rendering.junctionPointRendering, includeChildren)) {
+                return true
+            }
+        }
+    }
+    return false
 }
 
 /**
@@ -84,9 +115,8 @@ export function findRendering(element: SKGraphElement, id: string): KRendering |
                     nextElement = (currentElement as KPolyline).junctionPointRendering
                 }
             } if (nextElement === undefined) {
-                console.error(id + ' can not be found in the renderings of the element:')
-                console.error(element)
-                return
+                // This ID does not exist in the renderings, therefore does not belong to them.
+                return undefined
             }
             currentElement = nextElement
         }

--- a/packages/klighd-core/src/views-rendering.tsx
+++ b/packages/klighd-core/src/views-rendering.tsx
@@ -27,6 +27,7 @@ import {
     KRoundedRectangle, KShadow, KText, KVerticalAlignment, K_ARC, K_CHILD_AREA, K_CONTAINER_RENDERING, K_CUSTOM_RENDERING, K_ELLIPSE, K_IMAGE, K_POLYGON, K_POLYLINE, K_RECTANGLE, K_RENDERING_LIBRARY,
     K_RENDERING_REF, K_ROUNDED_BENDS_POLYLINE, K_ROUNDED_RECTANGLE, K_SPLINE, K_TEXT, SKEdge, SKGraphElement, SKLabel, SKNode, VerticalAlignment
 } from './skgraph-models';
+import { hasAction } from './skgraph-utils';
 import { BoundsAndTransformation, calculateX, findBoundsAndTransformationData, getPoints } from './views-common';
 import {
     ColorStyles, DEFAULT_CLICKABLE_FILL, DEFAULT_FILL, getKStyles, getSvgColorStyle, getSvgColorStyles, getSvgLineStyles, getSvgShadowStyles, getSvgTextStyles, isInvisible,
@@ -1049,6 +1050,18 @@ export function renderKRendering(kRendering: KRendering,
     if (isOverlay) {
         // Don't render this now if we have an overlay, but remember it to be put on top by the node rendering.
         context.titles[context.titles.length - 1].push(svgRendering)
+        // If the overlay does not define actions, make it non-interactable to allow clicking through to elements behind.
+        if (!hasAction(kRendering, true)) {
+            // add pointer-events: none to the style attribute of this overlay.
+            if (!svgRendering.data) {
+                svgRendering.data = {}
+            }
+            if (!svgRendering.data.style) {
+                svgRendering.data.style = {}
+            }
+            svgRendering.data.style['pointer-events'] = 'none'
+
+        }
         return <g></g>
     } else {
         return svgRendering


### PR DESCRIPTION
Make scaled up title renderings click-through if no actions are defined on that rendering.
Fixes #90.
This does not replicate the Piccolo behavior 100%, as there action execution is handled front-to-back on the canvas, we here do the execution child-to-parents, which is not necessarily the same.