### PR TITLE
Show a default selection style if none is defined.

### DIFF
--- a/packages/klighd-core/src/skgraph-models.ts
+++ b/packages/klighd-core/src/skgraph-models.ts
@@ -16,7 +16,8 @@
  */
 
 import { KEdge, KGraphData, KGraphElement, KNode } from '@kieler/klighd-interactive/lib/constraint-classes';
-import { Bounds, boundsFeature, moveFeature, Point, popupFeature, RectangularPort, RGBColor, selectFeature, SLabel, SModelElement } from 'sprotty';
+import { boundsFeature, moveFeature, popupFeature, RectangularPort, RGBColor, selectFeature, SLabel, SModelElement } from 'sprotty';
+import { Bounds, Point } from 'sprotty-protocol'
 
 /**
  * This is the superclass of all elements of a graph such as nodes, edges, ports,
@@ -415,7 +416,7 @@ export enum Trigger {
 export interface KStyle {
     type: string
     propagateToChildren: boolean
-    modifierId: string
+    modifierId?: string
     selection: boolean
 }
 
@@ -426,8 +427,8 @@ export interface KStyle {
 export interface KColoring extends KStyle {
     color: RGBColor
     alpha: number
-    targetColor: RGBColor
-    targetAlpha: number
+    targetColor?: RGBColor
+    targetAlpha?: number
     gradientAngle: number
 }
 
@@ -514,7 +515,7 @@ export interface KLineJoin extends KStyle {
  */
 export interface KLineStyle extends KStyle {
     lineStyle: LineStyle
-    dashPattern: number[]
+    dashPattern?: number[]
     dashOffset: number
 }
 
@@ -704,6 +705,15 @@ export function isPolyline(test: KGraphData): test is KPolyline {
         || type === K_POLYGON
         || type === K_ROUNDED_BENDS_POLYLINE
         || type === K_SPLINE
+}
+
+/**
+ * Returns if the given parameter is a KText.
+ * @param test The potential KText
+ */
+export function isKText(test: KGraphData): test is KText {
+    const type = test.type
+    return type === K_TEXT
 }
 
 /**

--- a/packages/klighd-core/src/views-rendering.tsx
+++ b/packages/klighd-core/src/views-rendering.tsx
@@ -23,12 +23,12 @@ import { DetailLevel } from './depth-map';
 import { PaperShadows, SimplifySmallText, TextSimplificationThreshold, TitleScalingFactor } from './options/render-options-registry';
 import { SKGraphModelRenderer } from './skgraph-model-renderer';
 import {
-    Arc, HorizontalAlignment, isRendering, KArc, KChildArea, KContainerRendering, KForeground, KHorizontalAlignment, KImage, KPolyline, KRendering, KRenderingLibrary, KRenderingRef, KRoundedBendsPolyline,
+    Arc, HorizontalAlignment, KArc, KChildArea, KContainerRendering, KForeground, KHorizontalAlignment, KImage, KPolyline, KRendering, KRenderingLibrary, KRoundedBendsPolyline,
     KRoundedRectangle, KShadow, KText, KVerticalAlignment, K_ARC, K_CHILD_AREA, K_CONTAINER_RENDERING, K_CUSTOM_RENDERING, K_ELLIPSE, K_IMAGE, K_POLYGON, K_POLYLINE, K_RECTANGLE, K_RENDERING_LIBRARY,
-    K_RENDERING_REF, K_ROUNDED_BENDS_POLYLINE, K_ROUNDED_RECTANGLE, K_SPLINE, K_TEXT, SKEdge, SKGraphElement, SKLabel, SKNode, VerticalAlignment
+    K_ROUNDED_BENDS_POLYLINE, K_ROUNDED_RECTANGLE, K_SPLINE, K_TEXT, SKEdge, SKGraphElement, SKLabel, SKNode, VerticalAlignment
 } from './skgraph-models';
 import { hasAction } from './skgraph-utils';
-import { BoundsAndTransformation, calculateX, findBoundsAndTransformationData, getPoints } from './views-common';
+import { BoundsAndTransformation, calculateX, findBoundsAndTransformationData, getKRendering, getPoints } from './views-common';
 import {
     ColorStyles, DEFAULT_CLICKABLE_FILL, DEFAULT_FILL, getKStyles, getSvgColorStyle, getSvgColorStyles, getSvgLineStyles, getSvgShadowStyles, getSvgTextStyles, isInvisible,
     KStyles, LineStyles
@@ -881,7 +881,7 @@ export function renderKRendering(kRendering: KRendering,
     // The styles that should be propagated to the children of this rendering. Will be modified in the getKStyles call.
     const stylesToPropagate = new KStyles
     // Extract the styles of the rendering into a more presentable object.
-    const styles = getKStyles(parent, kRendering.styles, propagatedStyles, stylesToPropagate)
+    const styles = getKStyles(parent, kRendering, propagatedStyles, context, stylesToPropagate)
 
     // Determine the bounds of the rendering first and where it has to be placed.
     const isEdge = [K_POLYLINE, K_POLYGON, K_ROUNDED_BENDS_POLYLINE, K_SPLINE].includes(kRendering.type)
@@ -1066,36 +1066,6 @@ export function renderKRendering(kRendering: KRendering,
     } else {
         return svgRendering
     }
-}
-
-/**
- * Looks up the first KRendering in the list of data and returns it. KRenderingReferences are handled and dereferenced as well, so only 'real' renderings are returned.
- * @param datas The list of possible renderings.
- * @param context The rendering context for this rendering.
- */
-export function getKRendering(datas: KGraphData[], context: SKGraphModelRenderer): KRendering | undefined {
-    for (const data of datas) {
-        if (data === null)
-            continue
-        if (data.type === K_RENDERING_REF) {
-            if (context.kRenderingLibrary) {
-                const id = (data as KRenderingRef).properties['klighd.lsp.rendering.id'] as string
-                for (const rendering of context.kRenderingLibrary.renderings) {
-                    if ((rendering as KRendering).properties['klighd.lsp.rendering.id'] as string === id) {
-                        context.boundsMap = (data as KRenderingRef).properties['klighd.lsp.calculated.bounds.map']
-                        context.decorationMap = (data as KRenderingRef).properties['klighd.lsp.calculated.decoration.map']
-                        return rendering as KRendering
-                    }
-                }
-            } else {
-                console.log("No KRenderingLibrary for KRenderingRef in context");
-            }
-        }
-        if (isRendering(data)) {
-            return data
-        }
-    }
-    return undefined
 }
 
 /**


### PR DESCRIPTION
Replicates same behavior as in klighd.piccolo. With this root renderings of selected elements with no defined selection style will have a grey background and dashed outline resp. bold text.