### PR TITLE
Reopen new diagram widget on start for current active editor.

### DIFF
--- a/applications/klighd-vscode/src/extension.ts
+++ b/applications/klighd-vscode/src/extension.ts
@@ -42,6 +42,7 @@ export function activate(context: vscode.ExtensionContext): void {
     // This extension should persist data in workspace state, so it is different for
     // each project a user opens. To change this, assign another Memento to this constant.
     const mementoForPersistence = context.workspaceState;
+    // const storage = new LocalStorage()
 
     // Command provided for other extensions to register the LS used to generate diagrams with KLighD.
     context.subscriptions.push(
@@ -57,6 +58,12 @@ export function activate(context: vscode.ExtensionContext): void {
 
                 try {
                     const storageService = new StorageService(mementoForPersistence, client);
+
+                    // And make sure we register a serializer for our webview type
+                    const reopener = new KlighdWebviewReopener(storageService)
+                    context.subscriptions.push(
+                        klighdExtensionCreated(() => reopener.onExtensionCreated())
+                    )
                     const extension = new KLighDExtension(context, {
                         lsClient: client,
                         supportedFileEnding: fileEndings,
@@ -143,13 +150,7 @@ export function activate(context: vscode.ExtensionContext): void {
 
             extension.webviews.forEach((webview) => webview.dispatch(action));
         })
-    );    
-
-    // And make sure we register a serializer for our webview type
-    const reopener = new KlighdWebviewReopener()
-    context.subscriptions.push(
-        klighdExtensionCreated(() => reopener.onExtensionCreated())
-    )
+    );
 }
 
 function isLanguageClient(client: unknown): client is CommonLanguageClient {

--- a/applications/klighd-vscode/src/extension.ts
+++ b/applications/klighd-vscode/src/extension.ts
@@ -42,7 +42,6 @@ export function activate(context: vscode.ExtensionContext): void {
     // This extension should persist data in workspace state, so it is different for
     // each project a user opens. To change this, assign another Memento to this constant.
     const mementoForPersistence = context.workspaceState;
-    // const storage = new LocalStorage()
 
     // Command provided for other extensions to register the LS used to generate diagrams with KLighD.
     context.subscriptions.push(

--- a/applications/klighd-vscode/src/klighd-extension.ts
+++ b/applications/klighd-vscode/src/klighd-extension.ts
@@ -73,7 +73,7 @@ export class KLighDExtension extends SprottyLspVscodeExtension {
     private supportedFileEndings: string[];
 
     // This service is required here, so it can be hooked into created webviews.
-    private storageService: StorageService;
+    readonly storageService: StorageService;
 
     /**
      * Stored action handlers that where registered by another extension.
@@ -219,6 +219,7 @@ export class KLighDExtension extends SprottyLspVscodeExtension {
                             this.singleton = webView;
                         }
                     }
+                    this.storageService.setItem('diagramOpen', true);
                 }
             })
         );

--- a/applications/klighd-vscode/src/klighd-webview-reopener.ts
+++ b/applications/klighd-vscode/src/klighd-webview-reopener.ts
@@ -29,7 +29,7 @@ export class KlighdWebviewReopener {
 
     onExtensionCreated(): void {
         const diagramWasOpen = this.storage.getItem('diagramOpen')
-        if (diagramWasOpen) {
+        if (diagramWasOpen == undefined || diagramWasOpen) {
             const uri = window.activeTextEditor?.document.fileName
             if (uri) {
                 commands.executeCommand(command.diagramOpen, Uri.file(uri))

--- a/applications/klighd-vscode/src/klighd-webview-reopener.ts
+++ b/applications/klighd-vscode/src/klighd-webview-reopener.ts
@@ -17,15 +17,25 @@
 
 import { commands, Uri, window } from "vscode";
 import { command } from "./constants";
-
+import { StorageService } from "./storage/storage-service";
 
 export class KlighdWebviewReopener {
 
+    private readonly storage: StorageService
+
+    constructor(storage: StorageService) {
+        this.storage = storage
+    }
+
     onExtensionCreated(): void {
-        const uri = window.activeTextEditor?.document.fileName
-        if (uri) {
-            commands.executeCommand(command.diagramOpen, Uri.file(uri))
+        const diagramWasOpen = this.storage.getItem('diagramOpen')
+        if (diagramWasOpen) {
+            const uri = window.activeTextEditor?.document.fileName
+            if (uri) {
+                commands.executeCommand(command.diagramOpen, Uri.file(uri))
+            }
         }
+
     }
 
 }

--- a/applications/klighd-vscode/src/klighd-webview-reopener.ts
+++ b/applications/klighd-vscode/src/klighd-webview-reopener.ts
@@ -1,0 +1,31 @@
+/*
+ * KIELER - Kiel Integrated Environment for Layout Eclipse RichClient
+ *
+ * http://rtsys.informatik.uni-kiel.de/kieler
+ *
+ * Copyright 2022 by
+ * + Kiel University
+ *   + Department of Computer Science
+ *     + Real-Time and Embedded Systems Group
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+import { commands, Uri, window } from "vscode";
+import { command } from "./constants";
+
+
+export class KlighdWebviewReopener {
+
+    onExtensionCreated(): void {
+        const uri = window.activeTextEditor?.document.fileName
+        if (uri) {
+            commands.executeCommand(command.diagramOpen, Uri.file(uri))
+        }
+    }
+
+}

--- a/applications/klighd-vscode/src/klighd-webview.ts
+++ b/applications/klighd-vscode/src/klighd-webview.ts
@@ -19,6 +19,7 @@ import { SprottyDiagramIdentifier, SprottyWebviewOptions } from "sprotty-vscode"
 import { SprottyLspWebview } from "sprotty-vscode/lib/lsp";
 import { commands, ViewColumn, WebviewPanel, window } from "vscode";
 import { contextKeys } from "./constants";
+import { KLighDExtension } from "./klighd-extension";
 
 /**
  * Extends the SprottyLspWebview to communicate user preferences to the container,
@@ -114,7 +115,7 @@ export class KLighDWebview extends SprottyLspWebview {
             this.diagramIdentifier.diagramType || 'diagram',
             title,
             {
-                viewColumn: ViewColumn.Beside,
+                viewColumn: ViewColumn.Two,
                 preserveFocus: true // The original editor remains focused.
             },
             {
@@ -124,5 +125,12 @@ export class KLighDWebview extends SprottyLspWebview {
             });
         this.initializeWebview(diagramPanel.webview, title);
         return diagramPanel;
+    }
+
+    protected async connect(): Promise<void> {
+        super.connect();
+        this.disposables.push(this.diagramPanel.onDidDispose(() => {
+            (this.extension as KLighDExtension).storageService.setItem('diagramOpen', false)
+        }));
     }
 }

--- a/applications/klighd-vscode/src/storage/storage-service.ts
+++ b/applications/klighd-vscode/src/storage/storage-service.ts
@@ -61,6 +61,18 @@ export class StorageService {
         return this.memento.get<Record<string, any>>(StorageService.key) ?? {};
     }
 
+    setItem(key: string, value: any): void {
+        const data = this.getData();
+        data[key] = value;
+
+        this.updateData(data);
+    }
+
+    getItem(key: string): any {
+        const data = this.getData();
+        return data[key]
+    }
+
     private updateData(data: Record<string, any>) {
         this.memento.update(StorageService.key, data);
     }


### PR DESCRIPTION
Since the old webviewPanel does not refer to the old `SprottyWebview` (which is a `KlighdWebview`) cannot be readded to the list of available `KlighdWebview`s in `KlighdExtension` and the old panel cannot be used during the creation of a new `KlighdWebview` since it is `readonly`, we recreate the Diagram on the start of the extension for the currently active editor.