### PR TITLE
Open diagram if an editor is eventually selected.

### DIFF
--- a/applications/klighd-vscode/src/klighd-webview-reopener.ts
+++ b/applications/klighd-vscode/src/klighd-webview-reopener.ts
@@ -15,14 +15,14 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-import { commands, Uri, window } from "vscode";
+import { commands, Disposable, Uri, window } from "vscode";
 import { command } from "./constants";
 import { StorageService } from "./storage/storage-service";
 
 export class KlighdWebviewReopener {
 
     private readonly storage: StorageService
-    private toDispose: { dispose(): any }[] = []
+    private toDispose: Disposable[] = []
 
     constructor(storage: StorageService) {
         this.storage = storage


### PR DESCRIPTION
The diagram did not open if initially, no active text editor existed. Now the diagram opens when a text editor is selected and not if one was selected on startup.
(Everything or course only if the diagram was not closed)