### PR TITLE
Core: switched tabs + added quickbar for options

### DIFF
--- a/packages/klighd-core/src/bookmarks/bookmark-panel.tsx
+++ b/packages/klighd-core/src/bookmarks/bookmark-panel.tsx
@@ -31,8 +31,8 @@ import { Bookmark, GoToBookmarkAction, CreateBookmarkAction, DeleteBookmarkActio
 @injectable()
 export class BookmarkPanel extends SidebarPanel {
     // sets the bookmarkpanel at the bottom
-    // hirarchy is: first = -10; middle = 0; last = 10;
-    readonly position = 10; // --> last position
+    // hierarchy is: first elem has the lowest number. so the last one got the highest
+    readonly position = 10; // --> last position (at the moment)
     
     @inject(DISymbol.BookmarkRegistry) private bookmarkRegistry: BookmarkRegistry
 

--- a/packages/klighd-core/src/bookmarks/bookmark-panel.tsx
+++ b/packages/klighd-core/src/bookmarks/bookmark-panel.tsx
@@ -4,7 +4,7 @@
  *
  * http://rtsys.informatik.uni-kiel.de/kieler
  * 
- * Copyright 2021 by
+ * Copyright 2021-2023 by
  * + Kiel University
  *   + Department of Computer Science
  *     + Real-Time and Embedded Systems Group
@@ -18,7 +18,7 @@
 
 import { inject, injectable, postConstruct } from "inversify";
 import { VNode } from "snabbdom";
-import { html, IActionDispatcher, TYPES } from "sprotty"; // eslint-disable-line @typescript-eslint/no-unused-vars
+import { html } from "sprotty"; // eslint-disable-line @typescript-eslint/no-unused-vars
 import { DISymbol } from "../di.symbols";
 import { FeatherIcon } from '../feather-icons-snabbdom/feather-icons-snabbdom';
 import { SidebarPanel } from "../sidebar";
@@ -30,8 +30,10 @@ import { Bookmark, GoToBookmarkAction, CreateBookmarkAction, DeleteBookmarkActio
  */
 @injectable()
 export class BookmarkPanel extends SidebarPanel {
-
-    @inject(TYPES.IActionDispatcher) private actionDispatcher: IActionDispatcher;
+    // sets the bookmarkpanel at the bottom
+    // hirarchy is: first = -10; middle = 0; last = 10;
+    readonly position = 10; // --> last position
+    
     @inject(DISymbol.BookmarkRegistry) private bookmarkRegistry: BookmarkRegistry
 
     @postConstruct()

--- a/packages/klighd-core/src/options/general-panel.tsx
+++ b/packages/klighd-core/src/options/general-panel.tsx
@@ -51,7 +51,7 @@ export class GeneralPanel extends SidebarPanel {
         this.preferencesRegistry.onChange(() => this.update());
         this.renderOptionsRegistry.onChange(() => this.update());
 
-        this.assignQuickActions();
+        this.assignQuickActions()
     }
 
     get id(): string {
@@ -70,26 +70,7 @@ export class GeneralPanel extends SidebarPanel {
     render(): VNode {
         return (
             <div>
-                <div class-options__section="true">
-                    <h5 class-options__heading="true">Quick Actions</h5>
-                    <div class-options__button-group="true">
-                        {this.getQuickActions().map((action) => (
-                            <button
-                                title={action.title}
-                                class-options__icon-button="true"
-                                class-sidebar__enabled-button={!!action.state}
-                                on-click={() => {
-                                    if (action.effect) {
-                                        action.effect.apply(this)
-                                    }
-                                    this.handleQuickActionClick(action.key)
-                                }}
-                            >
-                                <FeatherIcon iconId={action.iconId}/>
-                            </button>
-                        ))}
-                    </div>
-                </div>
+                {this.createQuickActionsHTML()}
                 <div class-options__section="true">
                     <h5 class-options__heading="true">Synthesis</h5>
                     <SynthesisPicker

--- a/packages/klighd-core/src/options/general-panel.tsx
+++ b/packages/klighd-core/src/options/general-panel.tsx
@@ -29,6 +29,7 @@ import { SetPreferencesAction } from "./actions";
 import { CheckOption } from "./components/option-inputs";
 import { SynthesisPicker } from "./components/synthesis-picker";
 import { OptionsRenderer } from "./options-renderer";
+import { QuickActionsBar } from '../sidebar/sidebar-panel';
 
 /**
  * Sidebar panel that displays general diagram configurations,
@@ -70,7 +71,11 @@ export class GeneralPanel extends SidebarPanel {
     render(): VNode {
         return (
             <div>
-                {this.createQuickActionsHTML()}
+                <QuickActionsBar
+                    quickActions={this.getQuickActions()}
+                    onChange={this.handleQuickActionClick.bind(this)}
+                    thisSidebarPanel={this}
+                />
                 <div class-options__section="true">
                     <h5 class-options__heading="true">Synthesis</h5>
                     <SynthesisPicker

--- a/packages/klighd-core/src/options/general-panel.tsx
+++ b/packages/klighd-core/src/options/general-panel.tsx
@@ -37,8 +37,8 @@ import { OptionsRenderer } from "./options-renderer";
 @injectable()
 export class GeneralPanel extends SidebarPanel {
     // Sets this panel at the second position
-    // hirarchy is: first = -10; middle = 0; last = 10;
-    readonly position = 0; // --> middle position
+    // hierarchy is: first elem has the lowest number. so the last one got the highest
+    readonly position = 0; // --> middle position (at the moment)
                                                     
     @inject(DISymbol.SynthesesRegistry) private synthesesRegistry: SynthesesRegistry;
     @inject(DISymbol.PreferencesRegistry) private preferencesRegistry: PreferencesRegistry;
@@ -63,8 +63,8 @@ export class GeneralPanel extends SidebarPanel {
     }
 
     update(): void {
-        super.assignQuickActions();
-        super.update();
+        super.assignQuickActions()
+        super.update()
     }
 
     render(): VNode {
@@ -73,7 +73,7 @@ export class GeneralPanel extends SidebarPanel {
                 <div class-options__section="true">
                     <h5 class-options__heading="true">Quick Actions</h5>
                     <div class-options__button-group="true">
-                        {this.getQuickAction().map((action) => (
+                        {this.getQuickActions().map((action) => (
                             <button
                                 title={action.title}
                                 class-options__icon-button="true"

--- a/packages/klighd-core/src/options/options-panel.tsx
+++ b/packages/klighd-core/src/options/options-panel.tsx
@@ -24,6 +24,7 @@ import { OptionsRenderer } from "./options-renderer";
 import { DISymbol } from "../di.symbols";
 import { FeatherIcon } from '../feather-icons-snabbdom/feather-icons-snabbdom';
 import { SidebarPanel } from "../sidebar";
+import { QuickActionsBar } from '../sidebar/sidebar-panel';
 
 /** Sidebar panel that displays server provided KLighD options.  */
 @injectable()
@@ -57,7 +58,11 @@ export class OptionsPanel extends SidebarPanel {
     render(): VNode {
         return this.optionsRegistry.hasOptions() ? (
             <div> 
-                {this.createQuickActionsHTML()}
+                <QuickActionsBar
+                    quickActions={this.getQuickActions()}
+                    onChange={this.handleQuickActionClick.bind(this)}
+                    thisSidebarPanel={this}
+                />
                 {this.optionsRenderer.renderServerOptions({
                     actions: this.optionsRegistry.displayedActions,
                     layoutOptions: this.optionsRegistry.layoutOptions,

--- a/packages/klighd-core/src/options/options-panel.tsx
+++ b/packages/klighd-core/src/options/options-panel.tsx
@@ -3,7 +3,7 @@
  *
  * http://rtsys.informatik.uni-kiel.de/kieler
  *
- * Copyright 2021 by
+ * Copyright 2021-2023 by
  * + Kiel University
  *   + Department of Computer Science
  *     + Real-Time and Embedded Systems Group
@@ -28,12 +28,20 @@ import { SidebarPanel } from "../sidebar";
 /** Sidebar panel that displays server provided KLighD options.  */
 @injectable()
 export class OptionsPanel extends SidebarPanel {
+    // sets this panel at the top position
+    // hirarchy is: first = -10; middle = 0; last = 10;
+    readonly position = -10;  // --> first position                                                            
     @inject(DISymbol.OptionsRegistry) private optionsRegistry: OptionsRegistry;
     @inject(DISymbol.OptionsRenderer) private optionsRenderer: OptionsRenderer;
-
+    
     @postConstruct()
     init(): void {
         this.optionsRegistry.onChange(() => this.update());
+        this.assignQuickActions();
+    }
+    update(): void {
+        super.assignQuickActions();
+        super.update();
     }
 
     get id(): string {
@@ -46,11 +54,33 @@ export class OptionsPanel extends SidebarPanel {
 
     render(): VNode {
         return this.optionsRegistry.hasOptions() ? (
-            this.optionsRenderer.renderServerOptions({
-                actions: this.optionsRegistry.displayedActions,
-                layoutOptions: this.optionsRegistry.layoutOptions,
-                synthesisOptions: this.optionsRegistry.valuedSynthesisOptions,
-            })
+            <div> 
+                <div class-options__section="true">
+                    <h5 class-options__heading="true">Quick Actions</h5>
+                    <div class-options__button-group="true">
+                        {this.getQuickAction().map((action) => (
+                            <button
+                                title={action.title}
+                                class-options__icon-button="true"
+                                class-sidebar__enabled-button={!!action.state}
+                                on-click={() => {
+                                    if (action.effect) {
+                                        action.effect.apply(this)
+                                    }
+                                    this.handleQuickActionClick(action.key)
+                                }}
+                            >
+                                <FeatherIcon iconId={action.iconId}/>
+                            </button>
+                        ))}
+                    </div>
+                </div>
+                {this.optionsRenderer.renderServerOptions({
+                    actions: this.optionsRegistry.displayedActions,
+                    layoutOptions: this.optionsRegistry.layoutOptions,
+                    synthesisOptions: this.optionsRegistry.valuedSynthesisOptions,
+                })}
+            </div>
         ) : (
             <span>No options provided by the diagram server.</span>
         );

--- a/packages/klighd-core/src/options/options-panel.tsx
+++ b/packages/klighd-core/src/options/options-panel.tsx
@@ -38,12 +38,12 @@ export class OptionsPanel extends SidebarPanel {
     init(): void {
         this.optionsRegistry.onChange(() => this.update());
         this.renderOptionsRegistry.onChange(() => this.update());
-        this.assignQuickActions();
+        this.assignQuickActions()
     }
 
     update(): void {
-        super.assignQuickActions();
-        super.update();
+        super.assignQuickActions()
+        super.update()
     }
 
     get id(): string {
@@ -57,26 +57,7 @@ export class OptionsPanel extends SidebarPanel {
     render(): VNode {
         return this.optionsRegistry.hasOptions() ? (
             <div> 
-                <div class-options__section="true">
-                    <h5 class-options__heading="true">Quick Actions</h5>
-                    <div class-options__button-group="true">
-                        {this.getQuickActions().map((action) => (
-                            <button
-                                title={action.title}
-                                class-options__icon-button="true"
-                                class-sidebar__enabled-button={!!action.state}
-                                on-click={() => {
-                                    if (action.effect) {
-                                        action.effect.apply(this)
-                                    }
-                                    this.handleQuickActionClick(action.key)
-                                }}
-                            >
-                                <FeatherIcon iconId={action.iconId}/>
-                            </button>
-                        ))}
-                    </div>
-                </div>
+                {this.createQuickActionsHTML()}
                 {this.optionsRenderer.renderServerOptions({
                     actions: this.optionsRegistry.displayedActions,
                     layoutOptions: this.optionsRegistry.layoutOptions,

--- a/packages/klighd-core/src/options/options-panel.tsx
+++ b/packages/klighd-core/src/options/options-panel.tsx
@@ -29,16 +29,17 @@ import { SidebarPanel } from "../sidebar";
 @injectable()
 export class OptionsPanel extends SidebarPanel {
     // sets this panel at the top position
-    // hirarchy is: first = -10; middle = 0; last = 10;
-    readonly position = -10;  // --> first position                                                            
+    // hierarchy is: first elem has the lowest number. so the last one got the highest
+    readonly position = -10;  // --> first position (at the moment)                                                           
     @inject(DISymbol.OptionsRegistry) private optionsRegistry: OptionsRegistry;
     @inject(DISymbol.OptionsRenderer) private optionsRenderer: OptionsRenderer;
-    
+
     @postConstruct()
     init(): void {
         this.optionsRegistry.onChange(() => this.update());
         this.assignQuickActions();
     }
+
     update(): void {
         super.assignQuickActions();
         super.update();
@@ -58,7 +59,7 @@ export class OptionsPanel extends SidebarPanel {
                 <div class-options__section="true">
                     <h5 class-options__heading="true">Quick Actions</h5>
                     <div class-options__button-group="true">
-                        {this.getQuickAction().map((action) => (
+                        {this.getQuickActions().map((action) => (
                             <button
                                 title={action.title}
                                 class-options__icon-button="true"

--- a/packages/klighd-core/src/options/options-panel.tsx
+++ b/packages/klighd-core/src/options/options-panel.tsx
@@ -37,6 +37,7 @@ export class OptionsPanel extends SidebarPanel {
     @postConstruct()
     init(): void {
         this.optionsRegistry.onChange(() => this.update());
+        this.renderOptionsRegistry.onChange(() => this.update());
         this.assignQuickActions();
     }
 

--- a/packages/klighd-core/src/sidebar/sidebar-panel.ts
+++ b/packages/klighd-core/src/sidebar/sidebar-panel.ts
@@ -151,7 +151,11 @@ export abstract class SidebarPanel implements ISidebarPanel {
                 title: this.renderOptionsRegistry.getValueOrDefault(PinSidebarOption) ? "Unpin Sidebar" : "Pin Sidebar",
                 iconId: this.renderOptionsRegistry.getValueOrDefault(PinSidebarOption) ? "lock" : "unlock",
                 action: SetRenderOptionAction.create(PinSidebarOption.ID, !this.renderOptionsRegistry.getValueOrDefault(PinSidebarOption)),
-                state: this.renderOptionsRegistry.getValue(PinSidebarOption)
+                state: this.renderOptionsRegistry.getValue(PinSidebarOption),
+                effect: () => {
+                    this.actionDispatcher.dispatch(SetRenderOptionAction.create(PinSidebarOption.ID, !this.renderOptionsRegistry.getValue(PinSidebarOption)));
+                    this.update()
+            }
             },
         ];
         

--- a/packages/klighd-core/src/sidebar/sidebar-panel.ts
+++ b/packages/klighd-core/src/sidebar/sidebar-panel.ts
@@ -101,7 +101,7 @@ export abstract class SidebarPanel implements ISidebarPanel {
     abstract render(): VNode;
 
     /**
-     * this method inits the quickactions, if you wanna use it for a panel
+     * This method inits the quickactions, if you wanna use it for a panel.
      */
     protected assignQuickActions():void {
         this.quickActions = [
@@ -157,15 +157,25 @@ export abstract class SidebarPanel implements ISidebarPanel {
         
 
     }
-    public getQuickActions() :QuickActionOption[]{
-        return this.quickActions;
+
+    /**
+     * This method gets the quickactionsbar so tab panels can inherit it.
+     * @returns Quickactionsbar attribute so other classes can inherit it.
+     */
+    public getQuickActions(): QuickActionOption[] {
+        return this.quickActions
     }
+
+    /**
+     * This method handels if you click on one quickaction element as the name already tells.
+     * @param type Represents all quickaction-elements.
+     */
     protected handleQuickActionClick(type: PossibleQuickAction): void {
-        const action = this.getQuickActions().find((a) => a.key === type)?.action;
+        const action = this.getQuickActions().find((a) => a.key === type)?.action
 
-        if (!action) return;
+        if (!action) return
 
-        this.actionDispatcher.dispatch(action);
+        this.actionDispatcher.dispatch(action)
     }
 }
 

--- a/packages/klighd-core/src/sidebar/sidebar-panel.ts
+++ b/packages/klighd-core/src/sidebar/sidebar-panel.ts
@@ -15,19 +15,17 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
+import { RefreshDiagramAction } from "@kieler/klighd-interactive/lib/actions";
 import { inject, injectable } from "inversify";
 import { VNode } from "snabbdom";
-
-//rik imports
-import { RefreshDiagramAction } from "@kieler/klighd-interactive/lib/actions";
+import { IActionDispatcher, RequestExportSvgAction, TYPES } from "sprotty";
 import { CenterAction } from "sprotty-protocol";
 import { KlighdFitToScreenAction, RefreshLayoutAction } from "../actions/actions";
 import { CreateBookmarkAction } from "../bookmarks/bookmark";
-import { PossibleQuickAction, QuickActionOption } from "../options/option-models";
-import { SetRenderOptionAction } from "../options/actions";
-import { PinSidebarOption,RenderOptionsRegistry, ResizeToFit } from "../options/render-options-registry";
-import { IActionDispatcher, RequestExportSvgAction, TYPES } from "sprotty";
 import { DISymbol } from "../di.symbols";
+import { SetRenderOptionAction } from "../options/actions";
+import { PossibleQuickAction, QuickActionOption } from "../options/option-models";
+import { PinSidebarOption, RenderOptionsRegistry, ResizeToFit } from "../options/render-options-registry";
 
 
 /**
@@ -102,7 +100,10 @@ export abstract class SidebarPanel implements ISidebarPanel {
 
     abstract render(): VNode;
 
-    public assignQuickActions():void {
+    /**
+     * this method inits the quickactions, if you wanna use it for a panel
+     */
+    protected assignQuickActions():void {
         this.quickActions = [
             {
                 key: "center",
@@ -156,17 +157,15 @@ export abstract class SidebarPanel implements ISidebarPanel {
         
 
     }
-    public getQuickAction() :QuickActionOption[]{
+    public getQuickActions() :QuickActionOption[]{
         return this.quickActions;
     }
     protected handleQuickActionClick(type: PossibleQuickAction): void {
-        const action = this.getQuickAction().find((a) => a.key === type)?.action;
+        const action = this.getQuickActions().find((a) => a.key === type)?.action;
 
         if (!action) return;
 
         this.actionDispatcher.dispatch(action);
     }
-
-
 }
 

--- a/packages/klighd-core/src/sidebar/sidebar-panel.tsx
+++ b/packages/klighd-core/src/sidebar/sidebar-panel.tsx
@@ -165,7 +165,7 @@ export abstract class SidebarPanel implements ISidebarPanel {
                 effect: () => {
                     this.actionDispatcher.dispatch(SetRenderOptionAction.create(PinSidebarOption.ID, !this.renderOptionsRegistry.getValue(PinSidebarOption)));
                     this.update()
-            }
+                }
             },
         ];
         

--- a/packages/klighd-core/src/sidebar/sidebar-panel.tsx
+++ b/packages/klighd-core/src/sidebar/sidebar-panel.tsx
@@ -15,14 +15,17 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
+/** @jsx html */
 import { RefreshDiagramAction } from "@kieler/klighd-interactive/lib/actions";
 import { inject, injectable } from "inversify";
 import { VNode } from "snabbdom";
+import { html } from "sprotty"; // eslint-disable-line @typescript-eslint/no-unused-vars
 import { IActionDispatcher, RequestExportSvgAction, TYPES } from "sprotty";
 import { CenterAction } from "sprotty-protocol";
 import { KlighdFitToScreenAction, RefreshLayoutAction } from "../actions/actions";
 import { CreateBookmarkAction } from "../bookmarks/bookmark";
 import { DISymbol } from "../di.symbols";
+import { FeatherIcon } from '../feather-icons-snabbdom/feather-icons-snabbdom';
 import { SetRenderOptionAction } from "../options/actions";
 import { PossibleQuickAction, QuickActionOption } from "../options/option-models";
 import { PinSidebarOption, RenderOptionsRegistry, ResizeToFit } from "../options/render-options-registry";
@@ -102,6 +105,12 @@ export abstract class SidebarPanel implements ISidebarPanel {
 
     /**
      * This method inits the quickactions, if you wanna use it for a panel.
+     * To use these quckactions you have to use the getQuickActions() method to get the quickactions.
+     * Furthermore you have to call this assign method in update() and init().
+     * Also make sure you add the renderOptionsRegistry to the constructor init(), otherwise
+     * it won't update correctly.
+     * Please also add the html create method for the quickactions at the right place (createQuickActionsHTML() )
+     * (also add the right imports)
      */
     protected assignQuickActions():void {
         this.quickActions = [
@@ -179,5 +188,33 @@ export abstract class SidebarPanel implements ISidebarPanel {
         if (!action) return
 
         this.actionDispatcher.dispatch(action)
+    }
+
+    /**
+     * This method creates the quickactionsbar via html
+     */
+    protected createQuickActionsHTML(): void{
+        const quickactionsHTML=
+        <div class-options__section="true">
+            <h5 class-options__heading="true">Quick Actions</h5>
+            <div class-options__button-group="true">
+                {this.getQuickActions().map((action) => (
+                    <button
+                        title={action.title}
+                        class-options__icon-button="true"
+                        class-sidebar__enabled-button={!!action.state}
+                        on-click={() => {
+                            if (action.effect) {
+                                action.effect.apply(this)
+                            }
+                            this.handleQuickActionClick(action.key)
+                        }}
+                    >
+                        <FeatherIcon iconId={action.iconId}/>
+                    </button>
+                ))}
+            </div>
+        </div>
+        return quickactionsHTML
     }
 }

--- a/packages/klighd-core/src/sidebar/sidebar-panel.tsx
+++ b/packages/klighd-core/src/sidebar/sidebar-panel.tsx
@@ -74,6 +74,13 @@ export interface ISidebarPanel {
  * Abstract SidebarPanel that should be used as the base for a custom {@link ISidebarPanel}.
  *
  * This class simplifies the implementation around handling render updates.
+ * 
+ * 
+ * To use these quick actions you have to use the getQuickActions() method to get the quick actions.
+ * Furthermore you have to call the `assignQuickActions` method in update() and init().
+ * Also make sure you add the renderOptionsRegistry to the constructor init() via
+ * `this.renderOptionsRegistry.onChange(() => this.update())`
+ * Furthermore, add the html create method in the `render()` method via `<QuickActionsBar/>`
  */
 @injectable()
 export abstract class SidebarPanel implements ISidebarPanel {
@@ -104,15 +111,9 @@ export abstract class SidebarPanel implements ISidebarPanel {
     abstract render(): VNode;
 
     /**
-     * This method inits the quickactions, if you wanna use it for a panel.
-     * To use these quckactions you have to use the getQuickActions() method to get the quickactions.
-     * Furthermore you have to call this assign method in update() and init().
-     * Also make sure you add the renderOptionsRegistry to the constructor init(), otherwise
-     * it won't update correctly.
-     * Please also add the html create method for the quickactions at the right place (createQuickActionsHTML() )
-     * (also add the right imports)
+     * This method inits the quick actions, if you want to use them for a panel.
      */
-    protected assignQuickActions():void {
+    protected assignQuickActions(): void {
         this.quickActions = [
             {
                 key: "center",
@@ -190,31 +191,48 @@ export abstract class SidebarPanel implements ISidebarPanel {
         this.actionDispatcher.dispatch(action)
     }
 
+
+}
+
+/**
+ * The properties needed to create the quick actions bar.
+ */
+interface QuickActionsBarProps {
+    /** The quick actions this bar should show */
+    quickActions: QuickActionOption[]
     /**
-     * This method creates the quickactionsbar via html
+     * callback method for when a quick action is clicked.
+     * @param key The key of the quick action that was clicked.
      */
-    protected createQuickActionsHTML(): void{
-        const quickactionsHTML=
-        <div class-options__section="true">
-            <h5 class-options__heading="true">Quick Actions</h5>
-            <div class-options__button-group="true">
-                {this.getQuickActions().map((action) => (
-                    <button
-                        title={action.title}
-                        class-options__icon-button="true"
-                        class-sidebar__enabled-button={!!action.state}
-                        on-click={() => {
-                            if (action.effect) {
-                                action.effect.apply(this)
-                            }
-                            this.handleQuickActionClick(action.key)
-                        }}
-                    >
-                        <FeatherIcon iconId={action.iconId}/>
-                    </button>
-                ))}
-            </div>
+    onChange: (key: PossibleQuickAction) => void
+    /** The sidebar panel this quick actions bar is part of. */
+    thisSidebarPanel: SidebarPanel
+}
+
+/**
+ * This method creates the quick actions bar as a resuable component.
+ */
+export function QuickActionsBar(props: QuickActionsBarProps): VNode {
+    // The Sprotty jsx function always puts an additional 'props' key around the element, requiring this hack.
+    props = (props as any as {props: QuickActionsBarProps}).props
+    return <div class-options__section="true">
+        <h5 class-options__heading="true">Quick Actions</h5>
+        <div class-options__button-group="true">
+            {props.quickActions.map((action) => (
+                <button
+                    title={action.title}
+                    class-options__icon-button="true"
+                    class-sidebar__enabled-button={!!action.state}
+                    on-click={() => {
+                        if (action.effect) {
+                            action.effect.apply(props.thisSidebarPanel)
+                        }
+                        props.onChange(action.key)
+                    }}
+                >
+                    <FeatherIcon iconId={action.iconId}/>
+                </button>
+            ))}
         </div>
-        return quickactionsHTML
-    }
+    </div>
 }

--- a/packages/klighd-core/src/views-rendering.tsx
+++ b/packages/klighd-core/src/views-rendering.tsx
@@ -445,6 +445,7 @@ export function renderKText(rendering: KText,
             width={boundingBoxAndTransformation?.bounds?.width ?? 0}
             height={boundingBoxAndTransformation?.bounds?.height ?? 0}
             fill={colorStyles.background.color}
+            style={{'opacity': colorStyles.background.opacity ?? '1'}}
         />
     }
 


### PR DESCRIPTION
1. switched tabs, so that options are at first, general second, and bookmarks at last.
2. also gave them static values, because general was at -10 before and the others at default (0)
3. let sidebar-panel init the quickactionbar. now options and general inherit it. 
--> now options has a quickactionbar aswell.