### PR TITLE
allow tests with jsx dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "watch": "lerna run watch --parallel",
         "package": "lerna run build && lerna run package --parallel",
         "distribute": "lerna run build && lerna run distribute --parallel",
-        "test": "mocha --require ts-node/register --recursive \"packages/**/test/**/*.{ts,tsx}\""
+        "test": "mocha --require ts-node/register --require ignore-styles --recursive \"packages/**/test/**/*.{ts,tsx}\""
     },
     "devDependencies": {
         "@types/chai": "^4.3.4",
@@ -31,6 +31,7 @@
         "@typescript-eslint/parser": "^4.27.0",
         "chai": "^4.3.7",
         "eslint": "^7.28.0",
+        "ignore-styles": "5.0.1",
         "lerna": "^4.0.0",
         "mocha": "^10.2.0",
         "ts-node": "^10.9.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,11 @@
 {
     "compilerOptions": {
+        "experimentalDecorators": true,
         "types": ["mocha", "chai"],
         "lib": [
-            "es6",
+            "es2017",
             "dom"
-          ]
+          ],
+        "jsx": "react",
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5120,6 +5120,11 @@ iferr@^0.1.5:
   resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
   integrity sha1-xg7taebY/bazEEofy8ocGS3FtQE=
 
+ignore-styles@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/ignore-styles/-/ignore-styles-5.0.1.tgz#b49ef2274bdafcd8a4880a966bfe38d1a0bf4671"
+  integrity sha512-gQQmIznCETPLEzfg1UH4Cs2oRq+HBPl8quroEUNXT8oybEG7/0lqI3dGgDSRry6B9HcCXw3PVkFFS0FF3CMddg==
+
 ignore-walk@^3.0.3:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.4.tgz#c9a09f69b7c7b479a5d74ac1a3c0d4236d2a6335"


### PR DESCRIPTION
This changes some compiler options, especially to allow mocha to test .tsx files or test files transitively requiring other .tsx files.

This PR does not break anything in the current running system, but we should consider upgrading more versions and maybe the typescript compiler settings in the whole project, as started in the testS branch.