### PR TITLE
Update Deprecated Actions. Bump update-artifact to v4

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -38,12 +38,12 @@ jobs:
               env: 
                 NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
             # Artifacts have a few limitation and will always be zips. See: https://github.com/actions/upload-artifact#zipped-artifact-downloads
-            - uses: actions/upload-artifact@v2
+            - uses: actions/upload-artifact@v4
               with:
                   name: klighd-cli
                   path: applications/klighd-cli/bin
                   if-no-files-found: error
-            - uses: actions/upload-artifact@v2
+            - uses: actions/upload-artifact@v4
               with:
                   name: klighd-vsix
                   path: applications/klighd-vscode/klighd-vscode.vsix


### PR DESCRIPTION
see https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/