### PR TITLE
API fixes

### DIFF
--- a/applications/klighd-vscode/src/extension.ts
+++ b/applications/klighd-vscode/src/extension.ts
@@ -171,9 +171,16 @@ function isLanguageClient(client: unknown): client is LanguageClient {
     // Therefore, they are two different classes internally.
 
     // To work around this, we ensure that it is an object and check the object
-    // for the existence of a few methods.
+    // for the existence of a few methods that are used in this extension.
 
-    const wantedMethod = ['onReady', 'sendNotification', 'onNotification', 'sendRequest', 'onRequest']
+    const wantedMethod = [
+        'needsStart',
+        'onDidChangeState',
+        'onNotification',
+        'onRequest',
+        'sendNotification',
+        'sendRequest',
+    ]
 
     const isObject = typeof client === 'object' && client !== null
     const hasWantedMethods = wantedMethod.every(

--- a/applications/klighd-vscode/src/webview-endpoint.ts
+++ b/applications/klighd-vscode/src/webview-endpoint.ts
@@ -3,7 +3,7 @@
  *
  * http://rtsys.informatik.uni-kiel.de/kieler
  *
- * Copyright 2023 by
+ * Copyright 2023-2024 by
  * + Kiel University
  *   + Department of Computer Science
  *     + Real-Time and Embedded Systems Group
@@ -57,14 +57,6 @@ export class KlighDWebviewEndpoint extends WebviewEndpoint {
         this.messenger.onRequest(
             LspRequest,
             async (request) => {
-                // Catch any diagram/accept action and call the registered action handlers.
-                if (request.method === 'diagram/accept' && isActionMessage(request.params)) {
-                    const { action } = request.params
-                    const handlers = this.klighdActionHandlers.get(request.params.action.kind)
-                    if (handlers) {
-                        handlers.forEach((handler) => handler(action))
-                    }
-                }
                 const result: any =
                     request.params === undefined
                         ? await this.languageClient.sendRequest(request.method)
@@ -81,6 +73,15 @@ export class KlighDWebviewEndpoint extends WebviewEndpoint {
         this.messenger.onNotification(
             LspNotification,
             (notification) => {
+                // Catch any diagram/accept action and call the registered action handlers.
+                if (notification.method === 'diagram/accept' && isActionMessage(notification.params)) {
+                    const { action } = notification.params
+                    const handlers = this.klighdActionHandlers.get(notification.params.action.kind)
+                    if (handlers) {
+                        handlers.forEach((handler) => handler(action))
+                        // TODO: if one of the handlers says the action does not need to be forwarded to the server, do not forward it.
+                    }
+                }
                 this.languageClient.sendNotification(notification.method, notification.params)
             },
             { sender: this.messageParticipant }


### PR DESCRIPTION
- Fix externally registered action handlers. (Sprotty actions are notifications, not requests)
- Fix required methods of language client (last update of vscode-languageclient had a breaking API change, requiring us to update the expected methods here)