### PR TITLE
Allow KImages to refer to arbitrary URIs, which will be linked in the SVG

### DIFF
--- a/packages/klighd-core/src/diagram-server.ts
+++ b/packages/klighd-core/src/diagram-server.ts
@@ -3,7 +3,7 @@
  *
  * http://rtsys.informatik.uni-kiel.de/kieler
  *
- * Copyright 2021 by
+ * Copyright 2021-2024 by
  * + Kiel University
  *   + Department of Computer Science
  *     + Real-Time and Embedded Systems Group
@@ -257,7 +257,8 @@ export class KlighdDiagramServer extends DiagramServerProxy {
         const notCached: Pair<string, string>[] = []
         for (const image of (action as CheckImagesAction).images) {
             const id = KlighdDiagramServer.imageToSessionStorageString(image.bundleName, image.imagePath)
-            if (!this.sessionStorage.getItem(id)) {
+            // "URI" as bundle name implies that the image path is a URI that should be resolved locally.
+            if (!this.sessionStorage.getItem(id) && image.bundleName !== 'URI') {
                 notCached.push({ k: image.bundleName, v: image.imagePath })
             }
         }


### PR DESCRIPTION
A first implementation to include images in the SVG outside of the bundled language server jar in the diagram. URIs available to the application can be used with this, e.g. URLs to images found online.
To refer to a URI image, add a KImage to the model with `bundleName = "URI"` and the URI in the `imagePath` attribute.

This implementation just refers to those images, a different implementation also enabling to refer to e.g. image files next to the visualized model will be worth expanding on this feature, as well as downloading and embedding the images in the SVG instead of linking to them for better compatibility during SVG export.