### PR TITLE
increase the sprotty imposed scroll limits to more reasonable values

### DIFF
--- a/packages/klighd-core/src/di.config.ts
+++ b/packages/klighd-core/src/di.config.ts
@@ -154,6 +154,8 @@ export default function createContainer(widgetId: string): Container {
             min: 0.00000000000001,
             max: 1000000000000000,
         },
+        horizontalScrollLimits: { min: -1000000000000000, max: 1000000000000000 },
+        verticalScrollLimits: { min: -1000000000000000, max: 1000000000000000 },
     })
     return container
 }


### PR DESCRIPTION
Large diagrams can now be scrolled freely again.