### PR TITLE
Only scale up titles if scaling is *strictly* larger than 1

### DIFF
--- a/packages/klighd-core/src/views-rendering.tsx
+++ b/packages/klighd-core/src/views-rendering.tsx
@@ -1373,7 +1373,7 @@ export function renderKRendering(
         }
         if (
             (((providingRegion && providingRegion.detail !== DetailLevel.FullDetails && parent.children.length > 1) ||
-                context.viewport.zoom <= titleScalingFactorOption) &&
+                context.viewport.zoom < titleScalingFactorOption) &&
                 !isProxy) ||
             scaleProxy
         ) {
@@ -1478,7 +1478,7 @@ export function renderKRendering(
                 (kRendering.properties['klighd.isNodeTitle'] as boolean) &&
                 (((!providingRegion || providingRegion.detail === DetailLevel.FullDetails) && !isProxy) ||
                     scaleProxy) &&
-                ((context.viewport.zoom <= titleScalingFactorOption && !isProxy) || scaleProxy) &&
+                ((context.viewport.zoom < titleScalingFactorOption && !isProxy) || scaleProxy) &&
                 // Don't draw if the rendering is an empty KText
                 (kRendering.type !== K_TEXT || (kRendering as KText).text !== '')
             ) {


### PR DESCRIPTION
Seems like a minor change, but if a diagram is centered, its scaling is set equal to 1, causing the title scaling to just kick in, although it does not scale anything yet. This removes the scaling at this exact 1-to-1 scaling for centered diagrams and lets it only kick in for zoomed out diagrams.