### PR TITLE
Improve production/development minimization/debuggability

### DIFF
--- a/applications/klighd-vscode/package.json
+++ b/applications/klighd-vscode/package.json
@@ -152,8 +152,8 @@
     "scripts": {
         "clean": "rimraf dist klighd-vscode.vsix",
         "lint": "eslint .",
-        "build": "webpack --mode development --devtool eval-source-map",
-        "watch": "webpack --watch --mode development --devtool eval-source-map",
+        "build": "webpack --mode production --devtool false",
+        "watch": "webpack --watch --mode development",
         "package": "vsce package --yarn --baseImagesUrl https://github.com/kieler/klighd-vscode/raw/HEAD/applications/klighd-vscode -o klighd-vscode.vsix",
         "predistribute": "yarn run package",
         "distribute": "yarn run distribute:vsce && yarn run distribute:ovsx",

--- a/applications/klighd-vscode/webpack.config.js
+++ b/applications/klighd-vscode/webpack.config.js
@@ -86,7 +86,7 @@ const webviewConfig = {
         filename: "webview.js",
         path: path.resolve(__dirname, "pack"),
     },
-    devtool: "nosources-source-map",
+    devtool: "eval-source-map",
 
     resolve: {
         extensions: [".ts", ".js"],


### PR DESCRIPTION
for production (build/package), do not use source maps, during development (watch), use the correct ones to make webview and extension debuggable.

This makes the generated extension code as small and efficient as possible (minified) when using the build/package commands and debuggable and readable when using the watch command.