### PR TITLE
Removes the double diagram request on opening VS Code with no editor in focus

### DIFF
--- a/applications/klighd-vscode/src/klighd-webview-reopener.ts
+++ b/applications/klighd-vscode/src/klighd-webview-reopener.ts
@@ -3,7 +3,7 @@
  *
  * http://rtsys.informatik.uni-kiel.de/kieler
  *
- * Copyright 2022-2023 by
+ * Copyright 2022-2024 by
  * + Kiel University
  *   + Department of Computer Science
  *     + Real-Time and Embedded Systems Group
@@ -35,19 +35,6 @@ export class KlighdWebviewReopener {
             if (activeTextEditor) {
                 const uri = activeTextEditor.document.fileName
                 commands.executeCommand(command.diagramOpen, Uri.file(uri))
-            } else {
-                // Register this an active editor changed to open the diagram then.
-                this.toDispose.push(
-                    window.onDidChangeActiveTextEditor((editor) => {
-                        let uri
-                        if (editor) {
-                            uri = editor.document.uri
-                        }
-                        commands.executeCommand(command.diagramOpen, uri)
-                        // Remove listener again
-                        this.toDispose.forEach((element) => element.dispose())
-                    })
-                )
             }
         }
     }


### PR DESCRIPTION
During adoption to Sprotty 0.13 another way of updating the diagram was introduced that always requests a diagram when the editor is switched. When opening VS Code now with no editor in focus (e.g. when the diagram was in focus, which is not re-opened by VS Code by default), clicking on an editor triggered this newly introduced switch AND this now-removed code we had for exactly that use case. As this is now superfluous and causes duplicated requests, this removes that issue.
See #162 