### PR TITLE
turn minimum line width into semantic line scaling. Also consider topdown layout scale.

### DIFF
--- a/packages/klighd-core/src/options/render-options-registry.ts
+++ b/packages/klighd-core/src/options/render-options-registry.ts
@@ -347,14 +347,14 @@ export class TitleScalingFactor implements RangeOption {
 /**
  * Boolean option to toggle the scaling of lines based on zoom level.
  */
-export class UseMinimumLineWidth implements RenderOption {
-    static readonly ID: string = 'use-minimum-line-width'
+export class UseLineScaling implements RenderOption {
+    static readonly ID: string = 'use-minimum-line-scale'
 
-    static readonly NAME: string = 'Minimum Line Width'
+    static readonly NAME: string = 'Use Line Scaling'
 
-    readonly id: string = UseMinimumLineWidth.ID
+    readonly id: string = UseLineScaling.ID
 
-    readonly name: string = UseMinimumLineWidth.NAME
+    readonly name: string = UseLineScaling.NAME
 
     readonly type: TransformationOptionType = TransformationOptionType.CHECK
 
@@ -363,7 +363,7 @@ export class UseMinimumLineWidth implements RenderOption {
     readonly renderCategory: string = SmartZoom.ID
 
     readonly description =
-        "Whether all borders and lines are at least as wide as set by the corresponding 'Minimum Line Width' option."
+        "Whether all borders and lines should be scaled to stay above a minimum threshold value set by the corresponding 'Minimum Line Scale' option."
 
     currentValue = true
 
@@ -371,18 +371,18 @@ export class UseMinimumLineWidth implements RenderOption {
 }
 
 /**
- * The size scaled lines should have as a minimum at any zoom level in pixels.
+ * The minumum scale lines should have at any zoom level.
  */
-export class MinimumLineWidth implements RangeOption {
-    static readonly ID: string = 'minimum-line-width'
+export class MinimumLineScale implements RangeOption {
+    static readonly ID: string = 'minimum-line-scale'
 
-    static readonly NAME: string = 'Minimum Line Width'
+    static readonly NAME: string = 'Minimum Line Scale'
 
     static readonly DEFAULT: number = 1
 
-    readonly id: string = MinimumLineWidth.ID
+    readonly id: string = MinimumLineScale.ID
 
-    readonly name: string = MinimumLineWidth.NAME
+    readonly name: string = MinimumLineScale.NAME
 
     readonly type: TransformationOptionType = TransformationOptionType.RANGE
 
@@ -400,7 +400,7 @@ export class MinimumLineWidth implements RangeOption {
     readonly renderCategory: string = SmartZoom.ID
 
     readonly description =
-        'The minium border or line width.\nIf set to 0.5 each edge or border is at least 0.5 pixel wide.'
+        'The minimum line scale.\nIf set to 0.5 each line uses at least 0.5 times of its width set by the synthesis.'
 
     currentValue = 0.5
 
@@ -533,8 +533,8 @@ export class RenderOptionsRegistry extends Registry {
 
         this.register(TitleScalingFactor)
 
-        this.register(UseMinimumLineWidth)
-        this.register(MinimumLineWidth)
+        this.register(UseLineScaling)
+        this.register(MinimumLineScale)
     }
 
     @postConstruct()

--- a/packages/klighd-core/src/options/render-options-registry.ts
+++ b/packages/klighd-core/src/options/render-options-registry.ts
@@ -371,7 +371,7 @@ export class UseLineScaling implements RenderOption {
 }
 
 /**
- * The minumum scale lines should have at any zoom level.
+ * The minimum scale lines should have at any zoom level.
  */
 export class MinimumLineScale implements RangeOption {
     static readonly ID: string = 'minimum-line-scale'

--- a/packages/klighd-core/src/views-styles.tsx
+++ b/packages/klighd-core/src/views-styles.tsx
@@ -19,7 +19,7 @@ import { KGraphData, SKGraphElement } from '@kieler/klighd-interactive/lib/const
 import Color = require('color')
 import { VNode } from 'snabbdom'
 import { getZoom, isSelectable, RGBColor, svg } from 'sprotty' // eslint-disable-line @typescript-eslint/no-unused-vars
-import { MinimumLineWidth, UseMinimumLineWidth } from './options/render-options-registry'
+import { MinimumLineScale, UseLineScaling } from './options/render-options-registry'
 import { SKGraphModelRenderer } from './skgraph-model-renderer'
 import {
     HorizontalAlignment,
@@ -863,17 +863,20 @@ export function isInvisible(styles: KStyles): boolean {
 export function getSvgLineStyles(styles: KStyles, target: SKGraphElement, context: SKGraphModelRenderer): LineStyles {
     // The line width as requested by the element
     let lineWidth = styles.kLineWidth === undefined ? DEFAULT_LINE_WIDTH : styles.kLineWidth.lineWidth
-    const useLineWidthOption = context.renderOptionsRegistry.getValue(UseMinimumLineWidth)
+    const useLineScaleOption = context.renderOptionsRegistry.getValue(UseLineScaling)
     // Only enable, if option is found.
-    const useMinimumLineWidth = useLineWidthOption ?? false
-    if (!context.forceRendering && useMinimumLineWidth) {
-        // The line witdh in px that the drawn line should not be less than.
-        const minimumLineWidth = context.renderOptionsRegistry.getValueOrDefault(MinimumLineWidth)
-        // The line width the requested one would have when rendered in the current zoom level.
-        const realLineWidth = lineWidth * getZoom(target)
-        if (realLineWidth !== 0 && realLineWidth < minimumLineWidth) {
-            // scale the used line width up to appear as big as the minimum line width requested.
-            lineWidth *= minimumLineWidth / realLineWidth
+    const useMinimumLineScale = useLineScaleOption ?? false
+    if (!context.forceRendering && useMinimumLineScale) {
+        // The line width in px that a 1px line should not be less than.
+        const minimumLineScale = context.renderOptionsRegistry.getValueOrDefault(MinimumLineScale)
+
+        // The scale that this line would be affected by
+        const scale = getZoom(target) * ((target.properties.absoluteScale as number) ?? 1)
+
+        // never scale down
+        if (lineWidth !== 0 && scale < minimumLineScale) {
+            // scale the line width up so that a 1px line appears as big as the minimum line width requested.
+            lineWidth *= minimumLineScale / scale
         }
     }
     const lineCap = styles.kLineCap === undefined ? undefined : lineCapText(styles.kLineCap)


### PR DESCRIPTION
- the scale introduced by topdown layout is also considered now
- the minimum line width turns into minimum line scale. That is, differences in line width as set by the synthesis are taken into account and all lines just have a minimum scale that they should have on screen. E.g., a line with a synthesis width of 3px and a minimum scale of 0.5 will always have at least a width on screen of 1.5px, etc.