### PR TITLE
Add pre-defined structural tags

### DIFF
--- a/packages/klighd-core/src/filtering/parser.ts
+++ b/packages/klighd-core/src/filtering/parser.ts
@@ -95,7 +95,7 @@ export function parse(ruleString: string): SemanticFilterRule {
     const operatorStack: Array<OperatorNode> = []
     const outputStack: Array<Node> = []
 
-    tokens.forEach((token, _index, _array) => {
+    tokens.forEach((token: string, _index, _array) => {
         if (OPERATORS.includes(token)) {
             while (
                 !(operatorStack.length === 0) &&

--- a/packages/klighd-core/src/filtering/reserved-structural-tags.ts
+++ b/packages/klighd-core/src/filtering/reserved-structural-tags.ts
@@ -18,13 +18,28 @@
 // We follow Sprotty's way of redeclaring the interface and its create function, so disable this lint check for this file.
 /* eslint-disable no-redeclare */
 import { SKGraphElement } from '@kieler/klighd-interactive/lib/constraint-classes'
+import { SEdgeImpl } from 'sprotty'
+import { FluentIterable, toArray } from 'sprotty/lib/utils/iterable'
+import { SKEdge, SKLabel, SKNode, SKPort } from '../skgraph-models'
 
 const reservedStructuralTags: Record<string, (el: SKGraphElement) => boolean> = {
     children: (el: SKGraphElement) => el.children.length !== 0,
+    isNode: (el: SKGraphElement) => el instanceof SKNode,
+    isEdge: (el: SKGraphElement) => el instanceof SKEdge,
+    isPort: (el: SKGraphElement) => el instanceof SKPort,
+    isLabel: (el: SKGraphElement) => el instanceof SKLabel,
+    edgeDegree: (el: SKGraphElement) =>
+        toArray(getIncomingEdgesIfNode(el)).length + toArray(getOutgoingEdgesIfNode(el)).length !== 0,
+    inDegree: (el: SKGraphElement) => toArray(getIncomingEdgesIfNode(el)).length !== 0,
+    outDegree: (el: SKGraphElement) => toArray(getOutgoingEdgesIfNode(el)).length !== 0,
 }
 
 const reservedNumericTags: Record<string, (el: SKGraphElement) => number> = {
     children: (el: SKGraphElement) => el.children.length,
+    edgeDegree: (el: SKGraphElement) =>
+        toArray(getIncomingEdgesIfNode(el)).length + toArray(getOutgoingEdgesIfNode(el)).length,
+    inDegree: (el: SKGraphElement) => toArray(getIncomingEdgesIfNode(el)).length,
+    outDegree: (el: SKGraphElement) => toArray(getOutgoingEdgesIfNode(el)).length,
 }
 
 export function isReservedStructuralTag(tag: string): boolean {
@@ -41,4 +56,18 @@ export function evaluateReservedStructuralTag(tag: string, element: SKGraphEleme
 
 export function evaluateReservedNumericTag(tag: string, element: SKGraphElement): number {
     return reservedNumericTags[tag](element)
+}
+
+function getIncomingEdgesIfNode(element: SKGraphElement): FluentIterable<SEdgeImpl> {
+    if (element instanceof SKNode) {
+        return element.incomingEdges
+    }
+    return []
+}
+
+function getOutgoingEdgesIfNode(element: SKGraphElement): FluentIterable<SEdgeImpl> {
+    if (element instanceof SKNode) {
+        return element.outgoingEdges
+    }
+    return []
 }

--- a/packages/klighd-core/src/filtering/reserved-structural-tags.ts
+++ b/packages/klighd-core/src/filtering/reserved-structural-tags.ts
@@ -22,6 +22,7 @@ import { SEdgeImpl } from 'sprotty'
 import { FluentIterable, toArray } from 'sprotty/lib/utils/iterable'
 import { SKEdge, SKLabel, SKNode, SKPort } from '../skgraph-models'
 
+/** Dictionary of boolean tags with their evaluation implementation. */
 const reservedStructuralTags: Record<string, (el: SKGraphElement) => boolean> = {
     children: (el: SKGraphElement) => el.children.length !== 0,
     isNode: (el: SKGraphElement) => el instanceof SKNode,
@@ -34,6 +35,7 @@ const reservedStructuralTags: Record<string, (el: SKGraphElement) => boolean> = 
     outDegree: (el: SKGraphElement) => toArray(getOutgoingEdgesIfNode(el)).length !== 0,
 }
 
+/** Dictionary of numeric tags with their evaluation implementation. */
 const reservedNumericTags: Record<string, (el: SKGraphElement) => number> = {
     children: (el: SKGraphElement) => el.children.length,
     edgeDegree: (el: SKGraphElement) =>
@@ -42,22 +44,47 @@ const reservedNumericTags: Record<string, (el: SKGraphElement) => number> = {
     outDegree: (el: SKGraphElement) => toArray(getOutgoingEdgesIfNode(el)).length,
 }
 
+/**
+ * Checks whether the given tag is a reserved boolean tag.
+ * @param tag the tag in question
+ * @returns true if it is reserved
+ */
 export function isReservedStructuralTag(tag: string): boolean {
     return tag in reservedStructuralTags
 }
 
+/**
+ * Checks whether the given tag is a reserved numeric tag.
+ * @param tag the tag in question
+ * @returns true if it is reserved
+ */
 export function isReservedNumericTag(tag: string): boolean {
     return tag in reservedNumericTags
 }
 
+/**
+ * Evaluates the given reserved tag. This function does not check again whether the tag exists and it should
+ * only be called after checking first with `isReservedStructuralTag`.
+ * @param tag The tag to be evaluated
+ * @param element The element to evaluate the tag on
+ * @returns True if the condition of the tag is fulfilled for the given element.
+ */
 export function evaluateReservedStructuralTag(tag: string, element: SKGraphElement): boolean {
     return reservedStructuralTags[tag](element)
 }
 
+/**
+ * Evaluates the given reserved tag. This function does not check again whether the tag exists and it should
+ * only be called after checking first with `isReservedNumericTag`.
+ * @param tag The tag to be evaluated
+ * @param element The element to evaluate the tag on
+ * @returns The value evaluated for tag for the given element.
+ */
 export function evaluateReservedNumericTag(tag: string, element: SKGraphElement): number {
     return reservedNumericTags[tag](element)
 }
 
+/** Helper function to get incoming edges. */
 function getIncomingEdgesIfNode(element: SKGraphElement): FluentIterable<SEdgeImpl> {
     if (element instanceof SKNode) {
         return element.incomingEdges
@@ -65,6 +92,7 @@ function getIncomingEdgesIfNode(element: SKGraphElement): FluentIterable<SEdgeIm
     return []
 }
 
+/** Helper function to get outgoing edges. */
 function getOutgoingEdgesIfNode(element: SKGraphElement): FluentIterable<SEdgeImpl> {
     if (element instanceof SKNode) {
         return element.outgoingEdges

--- a/packages/klighd-core/src/filtering/reserved-structural-tags.ts
+++ b/packages/klighd-core/src/filtering/reserved-structural-tags.ts
@@ -1,0 +1,44 @@
+/*
+ * KIELER - Kiel Integrated Environment for Layout Eclipse RichClient
+ *
+ * http://rtsys.informatik.uni-kiel.de/kieler
+ *
+ * Copyright 2025 by
+ * + Kiel University
+ *   + Department of Computer Science
+ *     + Real-Time and Embedded Systems Group
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+// We follow Sprotty's way of redeclaring the interface and its create function, so disable this lint check for this file.
+/* eslint-disable no-redeclare */
+import { SKGraphElement } from '@kieler/klighd-interactive/lib/constraint-classes'
+
+const reservedStructuralTags: Record<string, (el: SKGraphElement) => boolean> = {
+    children: (el: SKGraphElement) => el.children.length !== 0,
+}
+
+const reservedNumericTags: Record<string, (el: SKGraphElement) => number> = {
+    children: (el: SKGraphElement) => el.children.length,
+}
+
+export function isReservedStructuralTag(tag: string): boolean {
+    return tag in reservedStructuralTags
+}
+
+export function isReservedNumericTag(tag: string): boolean {
+    return tag in reservedNumericTags
+}
+
+export function evaluateReservedStructuralTag(tag: string, element: SKGraphElement): boolean {
+    return reservedStructuralTags[tag](element)
+}
+
+export function evaluateReservedNumericTag(tag: string, element: SKGraphElement): number {
+    return reservedNumericTags[tag](element)
+}

--- a/packages/klighd-core/src/filtering/reserved-structural-tags.ts
+++ b/packages/klighd-core/src/filtering/reserved-structural-tags.ts
@@ -45,32 +45,17 @@ const reservedNumericTags: Record<string, (el: SKGraphElement) => number> = {
 }
 
 /**
- * Checks whether the given tag is a reserved boolean tag.
- * @param tag the tag in question
- * @returns true if it is reserved
- */
-export function isReservedStructuralTag(tag: string): boolean {
-    return tag in reservedStructuralTags
-}
-
-/**
- * Checks whether the given tag is a reserved numeric tag.
- * @param tag the tag in question
- * @returns true if it is reserved
- */
-export function isReservedNumericTag(tag: string): boolean {
-    return tag in reservedNumericTags
-}
-
-/**
  * Evaluates the given reserved tag. This function does not check again whether the tag exists and it should
  * only be called after checking first with `isReservedStructuralTag`.
  * @param tag The tag to be evaluated
  * @param element The element to evaluate the tag on
  * @returns True if the condition of the tag is fulfilled for the given element.
  */
-export function evaluateReservedStructuralTag(tag: string, element: SKGraphElement): boolean {
-    return reservedStructuralTags[tag](element)
+export function evaluateReservedStructuralTag(tag: string, element: SKGraphElement): boolean | undefined {
+    if (isReservedStructuralTag(tag)) {
+        return reservedStructuralTags[tag](element)
+    }
+    return undefined
 }
 
 /**
@@ -80,8 +65,29 @@ export function evaluateReservedStructuralTag(tag: string, element: SKGraphEleme
  * @param element The element to evaluate the tag on
  * @returns The value evaluated for tag for the given element.
  */
-export function evaluateReservedNumericTag(tag: string, element: SKGraphElement): number {
-    return reservedNumericTags[tag](element)
+export function evaluateReservedNumericTag(tag: string, element: SKGraphElement): number | undefined {
+    if (isReservedNumericTag(tag)) {
+        return reservedNumericTags[tag](element)
+    }
+    return undefined
+}
+
+/**
+ * Checks whether the given tag is a reserved boolean tag.
+ * @param tag the tag in question
+ * @returns true if it is reserved
+ */
+function isReservedStructuralTag(tag: string): boolean {
+    return tag in reservedStructuralTags
+}
+
+/**
+ * Checks whether the given tag is a reserved numeric tag.
+ * @param tag the tag in question
+ * @returns true if it is reserved
+ */
+function isReservedNumericTag(tag: string): boolean {
+    return tag in reservedNumericTags
 }
 
 /** Helper function to get incoming edges. */

--- a/packages/klighd-core/src/filtering/semantic-filtering-util.ts
+++ b/packages/klighd-core/src/filtering/semantic-filtering-util.ts
@@ -594,7 +594,7 @@ function getSemanticFilterTags(element: SKGraphElement) {
     return tags
 }
 
-/** Evaluates a rule that reutrns a numeric result. */
+/** Evaluates a rule that returns a numeric result. */
 function evaluateNumeric(rule: SemanticFilterRule, element: SKGraphElement): number {
     const tags: SemanticFilterTag[] = getSemanticFilterTags(element)
     // Rule is a Tag

--- a/packages/klighd-core/src/filtering/semantic-filtering-util.ts
+++ b/packages/klighd-core/src/filtering/semantic-filtering-util.ts
@@ -3,7 +3,7 @@
  *
  * http://rtsys.informatik.uni-kiel.de/kieler
  *
- * Copyright 2022-2023 by
+ * Copyright 2022-2025 by
  * + Kiel University
  *   + Department of Computer Science
  *     + Real-Time and Embedded Systems Group
@@ -18,6 +18,12 @@
 // We follow Sprotty's way of redeclaring the interface and its create function, so disable this lint check for this file.
 /* eslint-disable no-redeclare */
 import { SKGraphElement } from '@kieler/klighd-interactive/lib/constraint-classes'
+import {
+    evaluateReservedNumericTag,
+    evaluateReservedStructuralTag,
+    isReservedNumericTag,
+    isReservedStructuralTag,
+} from './reserved-structural-tags'
 
 /// / Base constructs ////
 
@@ -99,7 +105,7 @@ export class TrueConnective implements Connective {
 }
 
 export namespace TrueConnective {
-    export function evaluate(_conn: TrueConnective, _tags: Array<SemanticFilterTag>): boolean {
+    export function evaluate(_conn: TrueConnective, _element: SKGraphElement): boolean {
         return true
     }
 }
@@ -116,7 +122,7 @@ export class FalseConnective implements Connective {
 }
 
 export namespace FalseConnective {
-    export function evaluate(_conn: FalseConnective, _tags: Array<SemanticFilterTag>): boolean {
+    export function evaluate(_conn: FalseConnective, _element: SKGraphElement): boolean {
         return false
     }
 }
@@ -135,8 +141,8 @@ export class IdentityConnective implements UnaryConnective {
 }
 
 export namespace IdentityConnective {
-    export function evaluate(conn: IdentityConnective, tags: Array<SemanticFilterTag>): boolean {
-        return evaluateRule(conn.operand, tags)
+    export function evaluate(conn: IdentityConnective, element: SKGraphElement): boolean {
+        return evaluateRule(conn.operand, element)
     }
 }
 
@@ -157,8 +163,8 @@ export class NegationConnective implements UnaryConnective {
 }
 
 export namespace NegationConnective {
-    export function evaluate(conn: NegationConnective, tags: Array<SemanticFilterTag>): boolean {
-        return !evaluateRule(conn.operand, tags)
+    export function evaluate(conn: NegationConnective, element: SKGraphElement): boolean {
+        return !evaluateRule(conn.operand, element)
     }
 }
 
@@ -181,8 +187,8 @@ export class AndConnective implements BinaryConnective {
 }
 
 export namespace AndConnective {
-    export function evaluate(conn: AndConnective, tags: Array<SemanticFilterTag>): boolean {
-        return evaluateRule(conn.leftOperand, tags) && evaluateRule(conn.rightOperand, tags)
+    export function evaluate(conn: AndConnective, element: SKGraphElement): boolean {
+        return evaluateRule(conn.leftOperand, element) && evaluateRule(conn.rightOperand, element)
     }
 }
 
@@ -205,8 +211,8 @@ export class OrConnective implements BinaryConnective {
 }
 
 export namespace OrConnective {
-    export function evaluate(conn: OrConnective, tags: Array<SemanticFilterTag>): boolean {
-        return evaluateRule(conn.leftOperand, tags) || evaluateRule(conn.rightOperand, tags)
+    export function evaluate(conn: OrConnective, element: SKGraphElement): boolean {
+        return evaluateRule(conn.leftOperand, element) || evaluateRule(conn.rightOperand, element)
     }
 }
 
@@ -230,8 +236,8 @@ export class IfThenConnective implements BinaryConnective {
 }
 
 export namespace IfThenConnective {
-    export function evaluate(conn: IfThenConnective, tags: Array<SemanticFilterTag>): boolean {
-        return !evaluateRule(conn.leftOperand, tags) || evaluateRule(conn.rightOperand, tags)
+    export function evaluate(conn: IfThenConnective, element: SKGraphElement): boolean {
+        return !evaluateRule(conn.leftOperand, element) || evaluateRule(conn.rightOperand, element)
     }
 }
 
@@ -255,8 +261,8 @@ export class LogicEqualConnective implements BinaryConnective {
 }
 
 export namespace LogicEqualConnective {
-    export function evaluate(conn: LogicEqualConnective, tags: Array<SemanticFilterTag>): boolean {
-        return evaluateRule(conn.leftOperand, tags) === evaluateRule(conn.rightOperand, tags)
+    export function evaluate(conn: LogicEqualConnective, element: SKGraphElement): boolean {
+        return evaluateRule(conn.leftOperand, element) === evaluateRule(conn.rightOperand, element)
     }
 }
 
@@ -282,10 +288,10 @@ export class IfThenElseConnective implements TernaryConnective {
 }
 
 export namespace IfThenElseConnective {
-    export function evaluate(conn: IfThenElseConnective, tags: Array<SemanticFilterTag>): boolean {
-        return evaluateRule(conn.firstOperand, tags)
-            ? evaluateRule(conn.secondOperand, tags)
-            : evaluateRule(conn.thirdOperand, tags)
+    export function evaluate(conn: IfThenElseConnective, element: SKGraphElement): boolean {
+        return evaluateRule(conn.firstOperand, element)
+            ? evaluateRule(conn.secondOperand, element)
+            : evaluateRule(conn.thirdOperand, element)
     }
 }
 
@@ -309,8 +315,8 @@ export class LessThanConnective implements BinaryConnective {
 }
 
 export namespace LessThanConnective {
-    export function evaluate(conn: LessThanConnective, tags: Array<SemanticFilterTag>): boolean {
-        return evaluateNumeric(conn.leftOperand, tags) < evaluateNumeric(conn.rightOperand, tags)
+    export function evaluate(conn: LessThanConnective, element: SKGraphElement): boolean {
+        return evaluateNumeric(conn.leftOperand, element) < evaluateNumeric(conn.rightOperand, element)
     }
 }
 
@@ -332,8 +338,8 @@ export class GreaterThanConnective implements BinaryConnective {
 }
 
 export namespace GreaterThanConnective {
-    export function evaluate(conn: GreaterThanConnective, tags: Array<SemanticFilterTag>): boolean {
-        return evaluateNumeric(conn.leftOperand, tags) > evaluateNumeric(conn.rightOperand, tags)
+    export function evaluate(conn: GreaterThanConnective, element: SKGraphElement): boolean {
+        return evaluateNumeric(conn.leftOperand, element) > evaluateNumeric(conn.rightOperand, element)
     }
 }
 
@@ -355,8 +361,8 @@ export class NumericEqualConnective implements BinaryConnective {
 }
 
 export namespace NumericEqualConnective {
-    export function evaluate(conn: NumericEqualConnective, tags: Array<SemanticFilterTag>): boolean {
-        return evaluateNumeric(conn.leftOperand, tags) === evaluateNumeric(conn.rightOperand, tags)
+    export function evaluate(conn: NumericEqualConnective, element: SKGraphElement): boolean {
+        return evaluateNumeric(conn.leftOperand, element) === evaluateNumeric(conn.rightOperand, element)
     }
 }
 
@@ -377,8 +383,8 @@ export class GreaterEqualsConnective implements BinaryConnective {
 }
 
 export namespace GreaterEqualsConnective {
-    export function evaluate(conn: GreaterEqualsConnective, tags: Array<SemanticFilterTag>): boolean {
-        return evaluateNumeric(conn.leftOperand, tags) >= evaluateNumeric(conn.rightOperand, tags)
+    export function evaluate(conn: GreaterEqualsConnective, element: SKGraphElement): boolean {
+        return evaluateNumeric(conn.leftOperand, element) >= evaluateNumeric(conn.rightOperand, element)
     }
 }
 
@@ -400,8 +406,8 @@ export class LessEqualsConnective implements BinaryConnective {
 }
 
 export namespace LessEqualsConnective {
-    export function evaluate(conn: LessEqualsConnective, tags: Array<SemanticFilterTag>): boolean {
-        return evaluateNumeric(conn.leftOperand, tags) <= evaluateNumeric(conn.rightOperand, tags)
+    export function evaluate(conn: LessEqualsConnective, element: SKGraphElement): boolean {
+        return evaluateNumeric(conn.leftOperand, element) <= evaluateNumeric(conn.rightOperand, element)
     }
 }
 
@@ -423,8 +429,8 @@ export class NumericNotEqualConnective implements BinaryConnective {
 }
 
 export namespace NumericNotEqualConnective {
-    export function evaluate(conn: NumericNotEqualConnective, tags: Array<SemanticFilterTag>): boolean {
-        return evaluateNumeric(conn.leftOperand, tags) !== evaluateNumeric(conn.rightOperand, tags)
+    export function evaluate(conn: NumericNotEqualConnective, element: SKGraphElement): boolean {
+        return evaluateNumeric(conn.leftOperand, element) !== evaluateNumeric(conn.rightOperand, element)
     }
 }
 
@@ -445,8 +451,8 @@ export class NumericAdditionConnective implements BinaryConnective {
 }
 
 export namespace NumericAdditionConnective {
-    export function evaluate(conn: NumericAdditionConnective, tags: Array<SemanticFilterTag>): number {
-        return evaluateNumeric(conn.leftOperand, tags) + evaluateNumeric(conn.rightOperand, tags)
+    export function evaluate(conn: NumericAdditionConnective, element: SKGraphElement): number {
+        return evaluateNumeric(conn.leftOperand, element) + evaluateNumeric(conn.rightOperand, element)
     }
 }
 
@@ -467,8 +473,8 @@ export class NumericSubtractionConnective implements BinaryConnective {
 }
 
 export namespace NumericSubtractionConnective {
-    export function evaluate(conn: NumericSubtractionConnective, tags: Array<SemanticFilterTag>): number {
-        return evaluateNumeric(conn.leftOperand, tags) - evaluateNumeric(conn.rightOperand, tags)
+    export function evaluate(conn: NumericSubtractionConnective, element: SKGraphElement): number {
+        return evaluateNumeric(conn.leftOperand, element) - evaluateNumeric(conn.rightOperand, element)
     }
 }
 
@@ -489,8 +495,8 @@ export class NumericMultiplicationConnective implements BinaryConnective {
 }
 
 export namespace NumericMultiplicationConnective {
-    export function evaluate(conn: NumericMultiplicationConnective, tags: Array<SemanticFilterTag>): number {
-        return evaluateNumeric(conn.leftOperand, tags) * evaluateNumeric(conn.rightOperand, tags)
+    export function evaluate(conn: NumericMultiplicationConnective, element: SKGraphElement): number {
+        return evaluateNumeric(conn.leftOperand, element) * evaluateNumeric(conn.rightOperand, element)
     }
 }
 
@@ -511,8 +517,8 @@ export class NumericDivisionConnective implements BinaryConnective {
 }
 
 export namespace NumericDivisionConnective {
-    export function evaluate(conn: NumericDivisionConnective, tags: Array<SemanticFilterTag>): number {
-        return evaluateNumeric(conn.leftOperand, tags) / evaluateNumeric(conn.rightOperand, tags)
+    export function evaluate(conn: NumericDivisionConnective, element: SKGraphElement): number {
+        return evaluateNumeric(conn.leftOperand, element) / evaluateNumeric(conn.rightOperand, element)
     }
 }
 
@@ -563,14 +569,7 @@ export function createFilter(rule: SemanticFilterRule): Filter {
     return {
         name: ruleName,
         defaultValue: rule.defaultValue,
-        filterFun: (el) => {
-            let tags: SemanticFilterTag[] = []
-            if (el.properties['de.cau.cs.kieler.klighd.semanticFilter.tags'] !== undefined) {
-                tags = el.properties['de.cau.cs.kieler.klighd.semanticFilter.tags'] as SemanticFilterTag[]
-            }
-
-            return evaluateRule(rule, tags)
-        },
+        filterFun: (el) => evaluateRule(rule, el),
     }
 }
 
@@ -588,12 +587,19 @@ function assertIsConnective(rule: Connective | SemanticFilterRule): asserts rule
 
 /**
  * Evaluates a rule that reutrns a numeric result. */
-function evaluateNumeric(rule: SemanticFilterRule, tags: Array<SemanticFilterTag>): number {
+function evaluateNumeric(rule: SemanticFilterRule, element: SKGraphElement): number {
+    let tags: SemanticFilterTag[] = []
+    if (element.properties['de.cau.cs.kieler.klighd.semanticFilter.tags'] !== undefined) {
+        tags = element.properties['de.cau.cs.kieler.klighd.semanticFilter.tags'] as SemanticFilterTag[]
+    }
     // Rule is a Tag
     if (isTag(rule)) {
         const nodeTag = tags.find((tag: SemanticFilterTag) => tag.tag === rule.tag)
         if (nodeTag !== undefined) {
             return nodeTag.num
+        }
+        if (isReservedNumericTag(rule.tag)) {
+            return evaluateReservedNumericTag(rule.tag, element)
         }
         return 0
     }
@@ -602,23 +608,31 @@ function evaluateNumeric(rule: SemanticFilterRule, tags: Array<SemanticFilterTag
         case NumericConstantConnective.NAME:
             return NumericConstantConnective.evaluate(rule as NumericConstantConnective)
         case NumericAdditionConnective.NAME:
-            return NumericAdditionConnective.evaluate(rule as NumericAdditionConnective, tags)
+            return NumericAdditionConnective.evaluate(rule as NumericAdditionConnective, element)
         case NumericSubtractionConnective.NAME:
-            return NumericSubtractionConnective.evaluate(rule as NumericSubtractionConnective, tags)
+            return NumericSubtractionConnective.evaluate(rule as NumericSubtractionConnective, element)
         case NumericMultiplicationConnective.NAME:
-            return NumericMultiplicationConnective.evaluate(rule as NumericMultiplicationConnective, tags)
+            return NumericMultiplicationConnective.evaluate(rule as NumericMultiplicationConnective, element)
         case NumericDivisionConnective.NAME:
-            return NumericDivisionConnective.evaluate(rule as NumericDivisionConnective, tags)
+            return NumericDivisionConnective.evaluate(rule as NumericDivisionConnective, element)
         default:
             return 0
     }
 }
 
 /** Evaluates `rule` using `tags`. See Connectives for further explanation on evaluation. */
-function evaluateRule(rule: SemanticFilterRule, tags: Array<SemanticFilterTag>): boolean {
+function evaluateRule(rule: SemanticFilterRule, element: SKGraphElement): boolean {
+    let tags: SemanticFilterTag[] = []
+    if (element.properties['de.cau.cs.kieler.klighd.semanticFilter.tags'] !== undefined) {
+        tags = element.properties['de.cau.cs.kieler.klighd.semanticFilter.tags'] as SemanticFilterTag[]
+    }
     // Rule is a Tag
     if (isTag(rule)) {
-        return tags.some((tag: SemanticFilterTag) => tag.tag === rule.tag)
+        let result = tags.some((tag: SemanticFilterTag) => tag.tag === rule.tag)
+        if (!result && isReservedStructuralTag(rule.tag)) {
+            result = evaluateReservedStructuralTag(rule.tag, element)
+        }
+        return result
     }
 
     // Rule is a Connective
@@ -626,23 +640,23 @@ function evaluateRule(rule: SemanticFilterRule, tags: Array<SemanticFilterTag>):
     switch (rule.name) {
         // Logic Connectives
         case TrueConnective.NAME:
-            return TrueConnective.evaluate(rule as TrueConnective, tags)
+            return TrueConnective.evaluate(rule as TrueConnective, element)
         case FalseConnective.NAME:
-            return FalseConnective.evaluate(rule as FalseConnective, tags)
+            return FalseConnective.evaluate(rule as FalseConnective, element)
         case IdentityConnective.NAME:
-            return IdentityConnective.evaluate(rule as IdentityConnective, tags)
+            return IdentityConnective.evaluate(rule as IdentityConnective, element)
         case NegationConnective.NAME:
-            return NegationConnective.evaluate(rule as NegationConnective, tags)
+            return NegationConnective.evaluate(rule as NegationConnective, element)
         case AndConnective.NAME:
-            return AndConnective.evaluate(rule as AndConnective, tags)
+            return AndConnective.evaluate(rule as AndConnective, element)
         case OrConnective.NAME:
-            return OrConnective.evaluate(rule as OrConnective, tags)
+            return OrConnective.evaluate(rule as OrConnective, element)
         case IfThenConnective.NAME:
-            return IfThenConnective.evaluate(rule as IfThenConnective, tags)
+            return IfThenConnective.evaluate(rule as IfThenConnective, element)
         case LogicEqualConnective.NAME:
-            return LogicEqualConnective.evaluate(rule as LogicEqualConnective, tags)
+            return LogicEqualConnective.evaluate(rule as LogicEqualConnective, element)
         case IfThenElseConnective.NAME:
-            return IfThenElseConnective.evaluate(rule as IfThenElseConnective, tags)
+            return IfThenElseConnective.evaluate(rule as IfThenElseConnective, element)
         // Numeric Connectives
         /*
         For now, these are defined by an unset corresponding tag being treated as if its num was 0. TODO:
@@ -652,17 +666,17 @@ function evaluateRule(rule: SemanticFilterRule, tags: Array<SemanticFilterTag>):
         Should this redefined, make sure to check all cases, e.g. !(x < y) === x >= y, de morgan, etc.
         */
         case LessThanConnective.NAME:
-            return LessThanConnective.evaluate(rule as LessThanConnective, tags)
+            return LessThanConnective.evaluate(rule as LessThanConnective, element)
         case GreaterThanConnective.NAME:
-            return GreaterThanConnective.evaluate(rule as GreaterThanConnective, tags)
+            return GreaterThanConnective.evaluate(rule as GreaterThanConnective, element)
         case NumericEqualConnective.NAME:
-            return NumericEqualConnective.evaluate(rule as NumericEqualConnective, tags)
+            return NumericEqualConnective.evaluate(rule as NumericEqualConnective, element)
         case GreaterEqualsConnective.NAME:
-            return GreaterEqualsConnective.evaluate(rule as GreaterEqualsConnective, tags)
+            return GreaterEqualsConnective.evaluate(rule as GreaterEqualsConnective, element)
         case LessEqualsConnective.NAME:
-            return LessEqualsConnective.evaluate(rule as LessEqualsConnective, tags)
+            return LessEqualsConnective.evaluate(rule as LessEqualsConnective, element)
         case NumericNotEqualConnective.NAME:
-            return NumericNotEqualConnective.evaluate(rule as NumericNotEqualConnective, tags)
+            return NumericNotEqualConnective.evaluate(rule as NumericNotEqualConnective, element)
         default:
             return true
     }

--- a/packages/klighd-core/src/filtering/semantic-filtering-util.ts
+++ b/packages/klighd-core/src/filtering/semantic-filtering-util.ts
@@ -585,13 +585,18 @@ function assertIsConnective(rule: Connective | SemanticFilterRule): asserts rule
     }
 }
 
-/**
- * Evaluates a rule that reutrns a numeric result. */
-function evaluateNumeric(rule: SemanticFilterRule, element: SKGraphElement): number {
+/** Extracts the semantic filter tags defined for an element. */
+function getSemanticFilterTags(element: SKGraphElement) {
     let tags: SemanticFilterTag[] = []
     if (element.properties['de.cau.cs.kieler.klighd.semanticFilter.tags'] !== undefined) {
         tags = element.properties['de.cau.cs.kieler.klighd.semanticFilter.tags'] as SemanticFilterTag[]
     }
+    return tags
+}
+
+/** Evaluates a rule that reutrns a numeric result. */
+function evaluateNumeric(rule: SemanticFilterRule, element: SKGraphElement): number {
+    const tags: SemanticFilterTag[] = getSemanticFilterTags(element)
     // Rule is a Tag
     if (isTag(rule)) {
         const nodeTag = tags.find((tag: SemanticFilterTag) => tag.tag === rule.tag)
@@ -622,10 +627,7 @@ function evaluateNumeric(rule: SemanticFilterRule, element: SKGraphElement): num
 
 /** Evaluates `rule` using `tags`. See Connectives for further explanation on evaluation. */
 function evaluateRule(rule: SemanticFilterRule, element: SKGraphElement): boolean {
-    let tags: SemanticFilterTag[] = []
-    if (element.properties['de.cau.cs.kieler.klighd.semanticFilter.tags'] !== undefined) {
-        tags = element.properties['de.cau.cs.kieler.klighd.semanticFilter.tags'] as SemanticFilterTag[]
-    }
+    const tags: SemanticFilterTag[] = getSemanticFilterTags(element)
     // Rule is a Tag
     if (isTag(rule)) {
         let result = tags.some((tag: SemanticFilterTag) => tag.tag === rule.tag)

--- a/packages/klighd-core/src/filtering/semantic-filtering-util.ts
+++ b/packages/klighd-core/src/filtering/semantic-filtering-util.ts
@@ -18,12 +18,7 @@
 // We follow Sprotty's way of redeclaring the interface and its create function, so disable this lint check for this file.
 /* eslint-disable no-redeclare */
 import { SKGraphElement } from '@kieler/klighd-interactive/lib/constraint-classes'
-import {
-    evaluateReservedNumericTag,
-    evaluateReservedStructuralTag,
-    isReservedNumericTag,
-    isReservedStructuralTag,
-} from './reserved-structural-tags'
+import { evaluateReservedNumericTag, evaluateReservedStructuralTag } from './reserved-structural-tags'
 
 /// / Base constructs ////
 
@@ -603,10 +598,7 @@ function evaluateNumeric(rule: SemanticFilterRule, element: SKGraphElement): num
         if (nodeTag !== undefined) {
             return nodeTag.num
         }
-        if (isReservedNumericTag(rule.tag)) {
-            return evaluateReservedNumericTag(rule.tag, element)
-        }
-        return 0
+        return evaluateReservedNumericTag(rule.tag, element) ?? 0
     }
     assertIsConnective(rule)
     switch (rule.name) {
@@ -631,8 +623,8 @@ function evaluateRule(rule: SemanticFilterRule, element: SKGraphElement): boolea
     // Rule is a Tag
     if (isTag(rule)) {
         let result = tags.some((tag: SemanticFilterTag) => tag.tag === rule.tag)
-        if (!result && isReservedStructuralTag(rule.tag)) {
-            result = evaluateReservedStructuralTag(rule.tag, element)
+        if (!result) {
+            result = evaluateReservedStructuralTag(rule.tag, element) ?? false
         }
         return result
     }

--- a/packages/klighd-core/test/filtering/parser.test.ts
+++ b/packages/klighd-core/test/filtering/parser.test.ts
@@ -235,4 +235,26 @@ describe('tag expression parsing', () => {
         }
         expect(filter.filterFun(negatedNode), 'has both #active and #disabled, so !#disabled fails').to.equal(false)
     })
+
+    it('structural tag: $children and #children', () => {
+        const ruleString = '$children >= 2'
+        const rule = parse(ruleString)
+        const filter = createFilter(rule)
+
+        const node = new SKNode()
+        node.properties = { 'de.cau.cs.kieler.klighd.semanticFilter.tags': [] }
+        const child1 = new SKNode()
+        child1.properties = { 'de.cau.cs.kieler.klighd.semanticFilter.tags': [] }
+        const child2 = new SKNode()
+        child2.properties = { 'de.cau.cs.kieler.klighd.semanticFilter.tags': [] }
+        node.children = [child1, child2]
+        expect(filter.filterFun(node), 'node with 2 children').to.equal(true)
+        expect(filter.filterFun(child1), 'node with 0 children').to.equal(false)
+
+        const ruleString2 = '#children'
+        const rule2 = parse(ruleString2)
+        const filter2 = createFilter(rule2)
+        expect(filter2.filterFun(node), 'node with 2 children').to.equal(true)
+        expect(filter2.filterFun(child1), 'node with 0 children').to.equal(false)
+    })
 })

--- a/packages/klighd-core/test/filtering/parser.test.ts
+++ b/packages/klighd-core/test/filtering/parser.test.ts
@@ -336,4 +336,82 @@ describe('tag expression parsing', () => {
         expect(filter2.filterFun(child2), 'node with incoming edge').to.equal(true)
         expect(filter2.filterFun(child3), 'node with no edges').to.equal(false)
     })
+
+    it('structural tag: $inDegree and #inDegree', () => {
+        const ruleString = '$inDegree >= 1'
+        const rule = parse(ruleString)
+        const filter = createFilter(rule)
+
+        const node = new SGraphImpl()
+        node.type = 'graph'
+        node.id = 'root'
+        const child1 = new SKNode()
+        child1.id = 'n1'
+        child1.properties = { 'de.cau.cs.kieler.klighd.semanticFilter.tags': [] }
+        const child2 = new SKNode()
+        child2.id = 'n2'
+        child2.properties = { 'de.cau.cs.kieler.klighd.semanticFilter.tags': [] }
+        const edge = new SKEdge()
+        edge.properties = { 'de.cau.cs.kieler.klighd.semanticFilter.tags': [] }
+        edge.targetId = 'n2'
+        edge.sourceId = 'n1'
+        node.add(child1)
+        node.add(child2)
+        child1.add(edge)
+
+        const child3 = new SKNode()
+        child3.id = 'n3'
+        child3.properties = { 'de.cau.cs.kieler.klighd.semanticFilter.tags': [] }
+        node.add(child3)
+
+        expect(filter.filterFun(child1), 'node with outgoing edge').to.equal(false)
+        expect(filter.filterFun(child2), 'node with incoming edge').to.equal(true)
+        expect(filter.filterFun(child3), 'node with no edges').to.equal(false)
+
+        const ruleString2 = '#inDegree'
+        const rule2 = parse(ruleString2)
+        const filter2 = createFilter(rule2)
+        expect(filter2.filterFun(child1), 'node with outgoing edge').to.equal(false)
+        expect(filter2.filterFun(child2), 'node with incoming edge').to.equal(true)
+        expect(filter2.filterFun(child3), 'node with no edges').to.equal(false)
+    })
+
+    it('structural tag: $outDegree and #outDegree', () => {
+        const ruleString = '$outDegree >= 1'
+        const rule = parse(ruleString)
+        const filter = createFilter(rule)
+
+        const node = new SGraphImpl()
+        node.type = 'graph'
+        node.id = 'root'
+        const child1 = new SKNode()
+        child1.id = 'n1'
+        child1.properties = { 'de.cau.cs.kieler.klighd.semanticFilter.tags': [] }
+        const child2 = new SKNode()
+        child2.id = 'n2'
+        child2.properties = { 'de.cau.cs.kieler.klighd.semanticFilter.tags': [] }
+        const edge = new SKEdge()
+        edge.properties = { 'de.cau.cs.kieler.klighd.semanticFilter.tags': [] }
+        edge.targetId = 'n2'
+        edge.sourceId = 'n1'
+        node.add(child1)
+        node.add(child2)
+        child1.add(edge)
+
+        const child3 = new SKNode()
+        child3.id = 'n3'
+        child3.properties = { 'de.cau.cs.kieler.klighd.semanticFilter.tags': [] }
+        node.add(child3)
+
+        expect(filter.filterFun(child1), 'node with outgoing edge').to.equal(true)
+        expect(filter.filterFun(child2), 'node with incoming edge').to.equal(false)
+        expect(filter.filterFun(child3), 'node with no edges').to.equal(false)
+
+        const ruleString2 = '#outDegree'
+        const rule2 = parse(ruleString2)
+        const filter2 = createFilter(rule2)
+        expect(filter2.filterFun(child1), 'node with outgoing edge').to.equal(true)
+        expect(filter2.filterFun(child2), 'node with incoming edge').to.equal(false)
+        expect(filter2.filterFun(child3), 'node with no edges').to.equal(false)
+    })
 })

--- a/packages/klighd-core/test/filtering/parser.test.ts
+++ b/packages/klighd-core/test/filtering/parser.test.ts
@@ -20,7 +20,7 @@ import { describe, it } from 'mocha'
 import { SGraphImpl } from 'sprotty'
 import { parse } from '../../src/filtering/parser'
 import { createFilter } from '../../src/filtering/semantic-filtering-util'
-import { SKEdge, SKNode } from '../../src/skgraph-models'
+import { SKEdge, SKLabel, SKNode, SKPort } from '../../src/skgraph-models'
 
 describe('tag expression parsing', () => {
     it('rule: #someTag && #anotherTag', () => {
@@ -257,6 +257,45 @@ describe('tag expression parsing', () => {
         const filter2 = createFilter(rule2)
         expect(filter2.filterFun(node), 'node with 2 children').to.equal(true)
         expect(filter2.filterFun(child1), 'node with 0 children').to.equal(false)
+    })
+
+    it('structural tags: #isNode, #isEdge, #isPort, #isLabel', () => {
+        const isNodeFilter = createFilter(parse('#isNode'))
+        const isEdgeFilter = createFilter(parse('#isEdge'))
+        const isPortFilter = createFilter(parse('#isPort'))
+        const isLabelFilter = createFilter(parse('#isLabel'))
+
+        const node = new SKNode()
+        node.properties = { 'de.cau.cs.kieler.klighd.semanticFilter.tags': [] }
+        expect(isNodeFilter.filterFun(node), 'node is node').to.equal(true)
+
+        const edge = new SKEdge()
+        edge.properties = { 'de.cau.cs.kieler.klighd.semanticFilter.tags': [] }
+        expect(isEdgeFilter.filterFun(edge), 'edge is edge').to.equal(true)
+
+        const port = new SKPort()
+        port.properties = { 'de.cau.cs.kieler.klighd.semanticFilter.tags': [] }
+        expect(isPortFilter.filterFun(port), 'port is port').to.equal(true)
+
+        const label = new SKLabel()
+        label.properties = { 'de.cau.cs.kieler.klighd.semanticFilter.tags': [] }
+        expect(isLabelFilter.filterFun(label), 'label is label').to.equal(true)
+
+        expect(isNodeFilter.filterFun(edge), 'node is not edge').to.equal(false)
+        expect(isNodeFilter.filterFun(port), 'node is not port').to.equal(false)
+        expect(isNodeFilter.filterFun(label), 'node is not label').to.equal(false)
+
+        expect(isEdgeFilter.filterFun(node), 'edge is not node').to.equal(false)
+        expect(isEdgeFilter.filterFun(port), 'edge is not port').to.equal(false)
+        expect(isEdgeFilter.filterFun(label), 'edge is not label').to.equal(false)
+
+        expect(isPortFilter.filterFun(node), 'port is not node').to.equal(false)
+        expect(isPortFilter.filterFun(edge), 'port is not edge').to.equal(false)
+        expect(isPortFilter.filterFun(label), 'port is not label').to.equal(false)
+
+        expect(isLabelFilter.filterFun(node), 'label is not node').to.equal(false)
+        expect(isLabelFilter.filterFun(edge), 'label is not edge').to.equal(false)
+        expect(isLabelFilter.filterFun(port), 'label is not port').to.equal(false)
     })
 
     it('structural tag: $edgeDegree and #edgeDegree', () => {


### PR DESCRIPTION
Introduces pre-defined structural tags. Common graph-structural properties can be filtered without requiring a synthesis author to add this information to the semantic tags.

Tags can be overridden by synthesis authors if desired. If the tag exists in the properties then that value is used rather than executing the defined behaviour.

The following table lists the new tags and their effects and whether a test has been written yet:
| tag | # | $ | has unit test |
|--------|--------|--------|---------|
| children | true if element has children | number of children | <ul><li>- [x] </li></ul> |
| isNode | true if element is node | *not reserved* | <ul><li>- [x] </li></ul> |
| isEdge | true if element is edge | *not reserved* | <ul><li>- [x] </li></ul> |
| isPort | true if element is port | *not reserved* | <ul><li>- [x] </li></ul> |
| isLabel | true if element is label | *not reserved* | <ul><li>- [x] </li></ul> |
| edgeDegree | true if element is node and has incident edges | number of incident edges |<ul><li>- [x] </li></ul> |
| inDegree | true if element is node and has incoming edges | number of incoming edges | <ul><li>- [x] </li></ul> |
| outDegree | true if element is node and has outgoing edges | number of outgoing edges | <ul><li>- [x] </li></ul>|