### PR TITLE
Add css property to limit diagram size by sidebar.

### DIFF
--- a/applications/klighd-vscode/package.json
+++ b/applications/klighd-vscode/package.json
@@ -145,6 +145,11 @@
                     "when": "keith-diagram-focused && klighd-vscode.syncWithEditor",
                     "command": "klighd-vscode.diagram.refresh",
                     "group": "navigation@1"
+                },
+                {
+                    "when": "keith-diagram-focused && klighd-vscode.syncWithEditor",
+                    "command": "klighd-vscode.diagram.fit",
+                    "group": "navigation@2"
                 }
             ]
         }

--- a/applications/klighd-vscode/src/commandContributions.ts
+++ b/applications/klighd-vscode/src/commandContributions.ts
@@ -21,7 +21,7 @@ import {
     RefreshLayoutAction,
 } from '@kieler/klighd-core'
 import 'reflect-metadata'
-import { CenterAction } from 'sprotty-protocol'
+import { CenterAction, FitToScreenAction } from 'sprotty-protocol'
 import * as vscode from 'vscode'
 import { command } from './constants'
 import { KLighDWebviewPanelManager } from './webview-panel-manager'
@@ -80,7 +80,12 @@ export function registerCommands(manager: KLighDWebviewPanelManager, context: vs
         vscode.commands.registerCommand(command.diagramRefresh, () => {
             const activeWebview = manager.findActiveWebview()
             if (activeWebview) {
-                activeWebview.sendAction(RefreshDiagramAction.create())
+                activeWebview.sendAction(RefreshDiagramAction.create()).then(() => {
+                    // If the diagram should resize to fit, send a resize to fit action.
+                    if (manager.storageService.getItem(FitToScreenAction.KIND)) {
+                        activeWebview.sendAction(KlighdFitToScreenAction.create(true))
+                    }
+                })
             }
         })
     )

--- a/packages/klighd-core/src/sidebar/sidebar.tsx
+++ b/packages/klighd-core/src/sidebar/sidebar.tsx
@@ -18,7 +18,15 @@
 /** @jsx html */
 import { inject, postConstruct } from 'inversify'
 import { VNode } from 'snabbdom'
-import { AbstractUIExtension, html, IActionDispatcher, InitializeCanvasBoundsAction, Patcher, PatcherProvider, TYPES } from 'sprotty' // eslint-disable-line @typescript-eslint/no-unused-vars
+import {
+    AbstractUIExtension,
+    html, // eslint-disable-line @typescript-eslint/no-unused-vars
+    IActionDispatcher,
+    InitializeCanvasBoundsAction,
+    Patcher,
+    PatcherProvider,
+    TYPES,
+} from 'sprotty'
 import { DISymbol } from '../di.symbols'
 import { PinSidebarOption, RenderOptionsRegistry } from '../options/render-options-registry'
 import { ShowSidebarAction, ToggleSidebarPanelAction } from './actions'
@@ -121,14 +129,16 @@ export class Sidebar extends AbstractUIExtension {
         }
         // Find the canvas element and dispatch an action to re-initialize the canvas bounds.
         // This works since the previous css property will correctly set the width of the canvas.
-        let canvas = (content.elm as HTMLElement).parentElement?.parentElement
+        const canvas = (content.elm as HTMLElement).parentElement?.parentElement
         if (canvas) {
-            this.actionDispatcher.dispatch(InitializeCanvasBoundsAction.create({
-                x: canvas.clientLeft,
-                y: canvas.clientTop,
-                width: canvas.clientWidth,
-                height: canvas.clientHeight
-            }));
+            this.actionDispatcher.dispatch(
+                InitializeCanvasBoundsAction.create({
+                    x: canvas.clientLeft,
+                    y: canvas.clientTop,
+                    width: canvas.clientWidth,
+                    height: canvas.clientHeight,
+                })
+            )
         }
     }
 

--- a/packages/klighd-core/src/sidebar/sidebar.tsx
+++ b/packages/klighd-core/src/sidebar/sidebar.tsx
@@ -116,29 +116,30 @@ export class Sidebar extends AbstractUIExtension {
         this.oldPanelContentRoot = this.patcher(this.oldPanelContentRoot, content)
 
         // Show or hide the panel
+        this.maxWidth = Math.max(this.maxWidth, this.containerElement.clientWidth)
         if (currentPanel) {
             this.containerElement.classList.add('sidebar--open')
             // Set width of sidebar to maximum width of all opened panels.
-            this.maxWidth = Math.max(this.maxWidth, this.containerElement.clientWidth)
             document.documentElement.style.setProperty('--sidebar-width', `${this.maxWidth}px`)
         } else {
             this.containerElement.classList.remove('sidebar--open')
             // Reset sidebar width when closed
-            this.maxWidth = Math.max(this.maxWidth, this.containerElement.clientWidth)
             document.documentElement.style.setProperty('--sidebar-width', '0px')
         }
         // Find the canvas element and dispatch an action to re-initialize the canvas bounds.
         // This works since the previous css property will correctly set the width of the canvas.
-        const canvas = (content.elm as HTMLElement).parentElement?.parentElement
-        if (canvas) {
-            this.actionDispatcher.dispatch(
-                InitializeCanvasBoundsAction.create({
-                    x: canvas.clientLeft,
-                    y: canvas.clientTop,
-                    width: canvas.clientWidth,
-                    height: canvas.clientHeight,
-                })
-            )
+        if (content.elm instanceof HTMLElement) {
+            const canvas = content.elm.parentElement?.parentElement
+            if (canvas) {
+                this.actionDispatcher.dispatch(
+                    InitializeCanvasBoundsAction.create({
+                        x: canvas.clientLeft,
+                        y: canvas.clientTop,
+                        width: canvas.clientWidth,
+                        height: canvas.clientHeight,
+                    })
+                )
+            }
         }
     }
 

--- a/packages/klighd-core/styles/main.css
+++ b/packages/klighd-core/styles/main.css
@@ -25,6 +25,7 @@
 .sprotty {
     /* Disable text selection in diagrams and sidebar panels. */
     user-select: none;
+    width: calc(100vw - var(--sidebar-width));
 }
 
 button > svg {


### PR DESCRIPTION
Currently, I do not know how to reset this variable properly when closing the sidebar.

Moreover, I seem to be missing some padding here, since the diagram is a little cut-off.

![image](https://github.com/user-attachments/assets/b7ace798-f1eb-45b6-985e-983396923686)
![image](https://github.com/user-attachments/assets/d9736e03-e357-41f6-bab6-26cfbe03d8ab)
