### PR TITLE
Open sidebar on mouseover if not fixed.

### DIFF
--- a/packages/klighd-core/src/sidebar/sidebar.tsx
+++ b/packages/klighd-core/src/sidebar/sidebar.tsx
@@ -94,6 +94,10 @@ export class Sidebar extends AbstractUIExtension {
                             class-sidebar__toggle-button--active={this.sidebarPanelRegistry.currentPanelID === panel.id}
                             title={panel.title}
                             on-click={this.handlePanelButtonClick.bind(this, panel.id)}
+                            // Return a on hover if the panel is not pinned.
+                            onmouseover={!this.sidebarPanelRegistry.currentPanelID
+                                ? this.handlePanelButtonClick.bind(this, panel.id)
+                                : () => {}}
                         >
                             {panel.icon}
                         </button>

--- a/packages/klighd-core/src/sidebar/sidebar.tsx
+++ b/packages/klighd-core/src/sidebar/sidebar.tsx
@@ -94,7 +94,7 @@ export class Sidebar extends AbstractUIExtension {
                             class-sidebar__toggle-button--active={this.sidebarPanelRegistry.currentPanelID === panel.id}
                             title={panel.title}
                             on-click={this.handlePanelButtonClick.bind(this, panel.id)}
-                            // Return a on hover if the panel is not pinned.
+                            // Return a on hover if the sidebar is not currently opened.
                             onmouseover={!this.sidebarPanelRegistry.currentPanelID
                                 ? this.handlePanelButtonClick.bind(this, panel.id)
                                 : () => {}}


### PR DESCRIPTION
Fixes #213 

By checking the panel id instead of contacting the renderoptions registry, this works very well.

However, this will open the sidebar onmouseover even though it is not pinned to be more reactive.

Maybe it would be a better idea to cache the pinned status rather than looking in the registry.

