### PR TITLE
Add fit command to diagram title menu.

### DIFF
--- a/applications/klighd-vscode/package.json
+++ b/applications/klighd-vscode/package.json
@@ -145,6 +145,11 @@
                     "when": "keith-diagram-focused && klighd-vscode.syncWithEditor",
                     "command": "klighd-vscode.diagram.refresh",
                     "group": "navigation@1"
+                },
+                {
+                    "when": "keith-diagram-focused && klighd-vscode.syncWithEditor",
+                    "command": "klighd-vscode.diagram.fit",
+                    "group": "navigation@2"
                 }
             ]
         }


### PR DESCRIPTION
While creating the other sidebar options, I found it annoying that the refresh does not do the fit to screen.
Therefore, I added this to the title bar such that I can do fit to screen without having the sidebar open.

This is conforming with how KIELER does it, which additionally has the XX commands in its "title menu".
VS Code
![image](https://github.com/user-attachments/assets/2d553662-2b4a-4ec7-bdd9-480ca2e7c8b6)

KIELER

![path849](https://github.com/user-attachments/assets/0ccd0135-e91a-487b-8f7b-df6e616aead9)

@Eddykasp @NiklasRentzCAU Do you think that all the buttons should be moved here, similar to KIELER?
