### PR TITLE
Add documentation to reserved tags

### DIFF
--- a/packages/klighd-core/src/filtering/reserved-structural-tags.ts
+++ b/packages/klighd-core/src/filtering/reserved-structural-tags.ts
@@ -35,7 +35,7 @@ const reservedStructuralTags: Record<string, FilterDefinition<boolean>> = {
     },
     childNodes: {
         description: 'True if there is at least one child that is a node.',
-        filter: (el: SKGraphElement) => el.children.filter((child) => child instanceof SKNode).length !== 0,
+        filter: (el: SKGraphElement) => el.children.some((child) => child instanceof SKNode),
     },
     isNode: {
         description: 'True if the graph element is a node.',

--- a/packages/klighd-core/src/filtering/reserved-structural-tags.ts
+++ b/packages/klighd-core/src/filtering/reserved-structural-tags.ts
@@ -121,7 +121,7 @@ export function evaluateReservedNumericTag(tag: string, element: SKGraphElement)
 
 /**
  * Returns the description for a given reserved tag if it is defined otherwise returns undefined
- * @param tag The tag whose descrtiption should be returned
+ * @param tag The tag whose description should be returned
  * @returns The description for the tag
  */
 export function descriptionForStructuralTag(tag: string): string | undefined {

--- a/packages/klighd-core/src/filtering/reserved-structural-tags.ts
+++ b/packages/klighd-core/src/filtering/reserved-structural-tags.ts
@@ -54,7 +54,7 @@ const reservedStructuralTags: Record<string, FilterDefinition<boolean>> = {
         filter: (el: SKGraphElement) => el instanceof SKLabel,
     },
     edgeDegree: {
-        description: 'True if the graph element is an edge.',
+        description: 'True if the graph element has at least one incident edge.',
         filter: (el: SKGraphElement) =>
             toArray(getIncomingEdgesIfNode(el)).length + toArray(getOutgoingEdgesIfNode(el)).length !== 0,
     },

--- a/packages/klighd-core/src/filtering/reserved-structural-tags.ts
+++ b/packages/klighd-core/src/filtering/reserved-structural-tags.ts
@@ -133,7 +133,7 @@ export function descriptionForStructuralTag(tag: string): string | undefined {
 
 /**
  * Returns the description for a given reserved tag if it is defined otherwise returns undefined
- * @param tag The tag whose descrtiption should be returned
+ * @param tag The tag whose description should be returned
  * @returns The description for the tag
  */
 export function descriptionForNumericTag(tag: string): string | undefined {

--- a/packages/klighd-core/test/filtering/reserved-structural-tags.test.ts
+++ b/packages/klighd-core/test/filtering/reserved-structural-tags.test.ts
@@ -26,13 +26,46 @@ describe('reserved structural tag evaluation', () => {
         const ruleString = '$children >= 2'
         const filter = createSemanticFilter(ruleString)
 
+        const root = new SGraphImpl()
+        root.type = 'graph'
+        root.id = 'root'
         const node = new SKNode()
         node.properties = { 'de.cau.cs.kieler.klighd.semanticFilter.tags': [] }
         const child1 = new SKNode()
         child1.properties = { 'de.cau.cs.kieler.klighd.semanticFilter.tags': [] }
         const child2 = new SKNode()
         child2.properties = { 'de.cau.cs.kieler.klighd.semanticFilter.tags': [] }
-        node.children = [child1, child2]
+        root.add(node)
+        node.add(child1)
+        node.add(child2)
+        expect(filter(node), 'node with 2 children').to.equal(true)
+        expect(filter(child1), 'node with 0 children').to.equal(false)
+
+        const ruleString2 = '#children'
+        const filter2 = createSemanticFilter(ruleString2)
+        expect(filter2(node), 'node with 2 children').to.equal(true)
+        expect(filter2(child1), 'node with 0 children').to.equal(false)
+    })
+
+    it('$childNodes and #childNodes', () => {
+        const ruleString = '$childNodes >= 2'
+        const filter = createSemanticFilter(ruleString)
+
+        const root = new SGraphImpl()
+        root.type = 'graph'
+        root.id = 'root'
+        const node = new SKNode()
+        node.properties = { 'de.cau.cs.kieler.klighd.semanticFilter.tags': [] }
+        const child1 = new SKNode()
+        child1.properties = { 'de.cau.cs.kieler.klighd.semanticFilter.tags': [] }
+        const child2 = new SKNode()
+        child2.properties = { 'de.cau.cs.kieler.klighd.semanticFilter.tags': [] }
+        const edge = new SKEdge()
+        edge.properties = { 'de.cau.cs.kieler.klighd.semanticFilter.tags': [] }
+        root.add(node)
+        node.add(child1)
+        node.add(child2)
+        node.add(edge)
         expect(filter(node), 'node with 2 children').to.equal(true)
         expect(filter(child1), 'node with 0 children').to.equal(false)
 

--- a/packages/klighd-core/test/filtering/reserved-structural-tags.test.ts
+++ b/packages/klighd-core/test/filtering/reserved-structural-tags.test.ts
@@ -60,18 +60,15 @@ describe('reserved structural tag evaluation', () => {
         child1.properties = { 'de.cau.cs.kieler.klighd.semanticFilter.tags': [] }
         const child2 = new SKNode()
         child2.properties = { 'de.cau.cs.kieler.klighd.semanticFilter.tags': [] }
-        const edge = new SKEdge()
-        edge.properties = { 'de.cau.cs.kieler.klighd.semanticFilter.tags': [] }
         root.add(node)
         node.add(child1)
         node.add(child2)
-        node.add(edge)
-        expect(filter(node), 'node with 2 children').to.equal(true)
+        expect(filter(node), 'node with 2 child nodes').to.equal(true)
         expect(filter(child1), 'node with 0 children').to.equal(false)
 
-        const ruleString2 = '#children'
+        const ruleString2 = '#childNodes'
         const filter2 = createSemanticFilter(ruleString2)
-        expect(filter2(node), 'node with 2 children').to.equal(true)
+        expect(filter2(node), 'node with 2 child nodes').to.equal(true)
         expect(filter2(child1), 'node with 0 children').to.equal(false)
     })
 


### PR DESCRIPTION
- descriptions for reserved tags can now be retrieved
- two new functions provide a list of all reserved tags
- add new tags #childNodes and $childNodes