### PR TITLE
fix string layout option handling in elkjs layout configurator

### DIFF
--- a/packages/klighd-core/src/di.config.ts
+++ b/packages/klighd-core/src/di.config.ts
@@ -84,7 +84,7 @@ const kGraphDiagramModule = new ContainerModule(
         // Our own layout configurator that just copies the element's poperties as the layout options.
         bind(KielerLayoutConfigurator).toSelf().inSingletonScope()
         rebind(ILayoutConfigurator).to(KielerLayoutConfigurator).inSingletonScope()
-        const elkFactory: ElkFactory = () => new ElkConstructor({ algorithms: ['layered'] }) // See elkjs documentation
+        const elkFactory: ElkFactory = () => new ElkConstructor() // See elkjs documentation
         bind(ElkFactory).toConstantValue(elkFactory)
 
         rebind(TYPES.CommandStackOptions).toConstantValue({

--- a/packages/klighd-core/src/layout-config.ts
+++ b/packages/klighd-core/src/layout-config.ts
@@ -3,7 +3,7 @@
  *
  * http://rtsys.informatik.uni-kiel.de/kieler
  *
- * Copyright 2024 by
+ * Copyright 2024-2025 by
  * + Kiel University
  *   + Department of Computer Science
  *     + Real-Time and Embedded Systems Group
@@ -33,7 +33,11 @@ export class KielerLayoutConfigurator extends DefaultLayoutConfigurator {
         // map properties to layout options and stringify values
         const layoutOptions: LayoutOptions = {}
         Object.entries(properties).forEach(([key, value]) => {
-            layoutOptions[key] = JSON.stringify(value)
+            if (typeof value === 'string') {
+                layoutOptions[key] = value
+            } else {
+                layoutOptions[key] = JSON.stringify(value)
+            }
         })
 
         return layoutOptions


### PR DESCRIPTION
fixes the sub-issue of #139. With this change, every layout algorithm can be used via the "algorithm" property again for client-side layout.