### PR TITLE
Correct handling of top-down scale factor in rendering

### DIFF
--- a/packages/klighd-core/src/views-rendering.tsx
+++ b/packages/klighd-core/src/views-rendering.tsx
@@ -149,12 +149,7 @@ export function renderChildArea(
         </g>
     )
 
-    // get scale factor and apply to child area
-    if (parent.properties === undefined || parent.properties['org.eclipse.elk.topdown.scaleFactor'] === undefined) {
-        return element
-    }
-    const topdownScaleFactor = parent.properties['org.eclipse.elk.topdown.scaleFactor'] as number
-    return <g transform={`scale (${topdownScaleFactor})`}>${element}</g>
+    return applyTopdownScale(element, parent)
 }
 
 /**
@@ -1655,17 +1650,24 @@ export function getJunctionPointRenderings(edge: SKEdge, context: SKGraphModelRe
 
     const renderings: VNode[] = []
 
-    let topdownScaleFactor = 1
-    if (
-        (edge.parent as any).properties !== undefined &&
-        (edge.parent as any).properties['org.eclipse.elk.topdown.scaleFactor'] !== undefined
-    ) {
-        topdownScaleFactor = (edge.parent as any).properties['org.eclipse.elk.topdown.scaleFactor'] as number
-    }
-
     edge.junctionPoints.forEach((junctionPoint) => {
         const junctionPointVNode = <g transform={`translate(${junctionPoint.x},${junctionPoint.y})`}>{vNode}</g>
-        renderings.push(<g transform={`scale (${topdownScaleFactor})`}>${junctionPointVNode}</g>)
+        renderings.push(junctionPointVNode)
     })
     return renderings
+}
+
+/**
+ * Applies the topdown scale factor, if present, to the returned rendering.
+ * @param element The non-scaled rendered element.
+ * @param parent The parent graph element that this rendering is for.
+ * @returns The (scaled) rendered element.
+ */
+export function applyTopdownScale(element: VNode, parent: SKGraphElement) {
+    // get scale factor and apply it
+    if (parent.properties === undefined || parent.properties['org.eclipse.elk.topdown.scaleFactor'] === undefined) {
+        return element
+    }
+    const topdownScaleFactor = parent.properties['org.eclipse.elk.topdown.scaleFactor'] as number
+    return <g transform={`scale(${topdownScaleFactor})`}>{element}</g>
 }

--- a/packages/klighd-core/src/views-rendering.tsx
+++ b/packages/klighd-core/src/views-rendering.tsx
@@ -1657,8 +1657,8 @@ export function getJunctionPointRenderings(edge: SKEdge, context: SKGraphModelRe
 
     let topdownScaleFactor = 1
     if (
-        (edge.parent as any).properties === undefined ||
-        (edge.parent as any).properties['org.eclipse.elk.topdown.scaleFactor'] === undefined
+        (edge.parent as any).properties !== undefined &&
+        (edge.parent as any).properties['org.eclipse.elk.topdown.scaleFactor'] !== undefined
     ) {
         topdownScaleFactor = (edge.parent as any).properties['org.eclipse.elk.topdown.scaleFactor'] as number
     }

--- a/packages/klighd-core/src/views.tsx
+++ b/packages/klighd-core/src/views.tsx
@@ -46,7 +46,7 @@ import { SKGraphModelRenderer } from './skgraph-model-renderer'
 import { SKEdge, SKLabel, SKNode, SKPort } from './skgraph-models'
 import { getViewportBounds } from './skgraph-utils'
 import { isFullDetail } from './views-common'
-import { getJunctionPointRenderings, getRendering } from './views-rendering'
+import { applyTopdownScale, getJunctionPointRenderings, getRendering } from './views-rendering'
 import { KStyles } from './views-styles'
 
 /**
@@ -303,7 +303,8 @@ export class KNodeView extends KGraphElementView {
         }
         // Default case. If no child area children or no non-child area children are already rendered within the rendering, add the children by default.
         if (!node.areChildAreaChildrenRendered) {
-            result.push(...ctx.renderChildren(node))
+            const element = <g>{...ctx.renderChildren(node)}</g>
+            result.push(applyTopdownScale(element, node))
         } else if (!node.areNonChildAreaChildrenRendered) {
             result.push(...ctx.renderNonChildAreaChildren(node))
         }


### PR DESCRIPTION
- no longer incorrectly applies scale to junction points
- top-down support for non-childarea children