### PR TITLE
proposal for implementing klighd properties in schema

### DIFF
--- a/schema/klighd/KlighdProperties.json
+++ b/schema/klighd/KlighdProperties.json
@@ -32,8 +32,11 @@
                     "default": "de.cau.cs.kieler.klighd.proxyView.proxyRendering"
                 },
                 "defaultValue": {
-                    "type": "boolean",
-                    "default": true
+                    "type": "array",
+                    "items": {
+                        "$ref": "./SKGraphSchema.json#/definitions/KGraphData"
+                    },
+                    "default": []
                 }
             }
         },

--- a/schema/klighd/KlighdProperties.json
+++ b/schema/klighd/KlighdProperties.json
@@ -1,0 +1,69 @@
+{
+    "$id": "https://github.com/kieler/klighd-vscode/tree/main/schema/klighd/KlighdProperties.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Property",
+    "type": "object",
+    "required": ["id", "defaultValue"],
+    "properties": {
+        "id": {
+            "type": "string"
+        },
+        "defaultValue": {}
+    },
+    "definitions": {
+        "ProxyViewRenderNodeAsProxy": {
+            "allOf": [{"$ref": "#"}],
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "default": "de.cau.cs.kieler.klighd.proxyView.renderNodeAsProxy"
+                },
+                "defaultValue": {
+                    "type": "boolean",
+                    "default": true
+                }
+            }
+        },
+        "ProxyViewProxyRendering": {
+            "allOf": [{"$ref": "#"}],
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "default": "de.cau.cs.kieler.klighd.proxyView.proxyRendering"
+                },
+                "defaultValue": {
+                    "type": "boolean",
+                    "default": true
+                }
+            }
+        },
+        "SemanticFilterTags": {
+            "allOf": [{"$ref": "#"}],
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "default": "de.cau.cs.kieler.klighd.semanticFilter.tags"
+                },
+                "defaultValue": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/SemanticFilterTag"
+                    },
+                    "default": []
+                }
+            }
+        },
+        "SemanticFilterTag": {
+            "type": "object",
+            "properties": {
+                "tag": {
+                    "type": "string"
+                },
+                "num": {
+                    "type": "number",
+                    "default": 0
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
generates the following python code:

```python
# generated by datamodel-codegen:
#   filename:  klighd/KlighdProperties.json
#   timestamp: 2026-02-25T12:13:19+00:00

from __future__ import annotations

from typing import Any, List, Optional

from pydantic import BaseModel


class Property(BaseModel):
    id: str
    defaultValue: Any


class ProxyViewRenderNodeAsProxy(Property):
    id: Optional[str] = 'de.cau.cs.kieler.klighd.proxyView.renderNodeAsProxy'
    defaultValue: Optional[bool] = True


class ProxyViewProxyRendering(Property):
    id: Optional[str] = 'de.cau.cs.kieler.klighd.proxyView.proxyRendering'
    defaultValue: Optional[bool] = True


class SemanticFilterTag(BaseModel):
    tag: Optional[str] = None
    num: Optional[float] = 0


class SemanticFilterTags(Property):
    id: Optional[str] = 'de.cau.cs.kieler.klighd.semanticFilter.tags'
    defaultValue: Optional[List[SemanticFilterTag]] = []

```