### PR TITLE
Nre/assorted fixes

### DIFF
--- a/packages/klighd-core/src/options/render-options-registry.ts
+++ b/packages/klighd-core/src/options/render-options-registry.ts
@@ -173,7 +173,7 @@ export class FullDetailRelativeThreshold implements RangeOption {
 
     static readonly NAME: string = 'Full Detail Relative Threshold'
 
-    static readonly DEFAULT: number = 0.15
+    static readonly DEFAULT: number = 0.1
 
     readonly id: string = FullDetailRelativeThreshold.ID
 
@@ -196,9 +196,9 @@ export class FullDetailRelativeThreshold implements RangeOption {
 
     readonly description =
         'Shows all children of an element that uses at least the amount of the canvas.' +
-        'A value of 0.2 means an element is shown if its parent has at least 0.2 the size (maximum of width and height) of the canvas.'
+        'A value of 0.1 means an element is shown if its parent has at least 0.1 the size (maximum of width and height) of the canvas.'
 
-    currentValue = 0.2
+    currentValue = 0.1
 
     debug = true
 }
@@ -240,6 +240,33 @@ export class FullDetailScaleThreshold implements RangeOption {
     currentValue = 0.25
 
     debug = true
+}
+
+/**
+ * Boolean option to enable and disable searching for a default title rendering if none is found
+ * in the element.
+ */
+export class UseDefaultTitleRendering implements RenderOption {
+    static readonly ID: string = 'use-default-title-rendering'
+
+    static readonly NAME: string = 'Default Title Rendering'
+
+    static readonly DEFAULT: boolean = false
+
+    readonly id: string = UseDefaultTitleRendering.ID
+
+    readonly name: string = UseDefaultTitleRendering.NAME
+
+    readonly type: TransformationOptionType = TransformationOptionType.CHECK
+
+    readonly initialValue: boolean = false
+
+    readonly renderCategory: string = SmartZoom.ID
+
+    readonly description =
+        'Enables default title renderings that will be scaled up by the "Smart Zoom" option. Uses the first text found in nodes that have no explicit title rendering.'
+
+    currentValue = true
 }
 
 /**
@@ -527,6 +554,7 @@ export class RenderOptionsRegistry extends Registry {
         this.register(UseSmartZoom)
         this.register(FullDetailRelativeThreshold)
         this.register(FullDetailScaleThreshold)
+        this.register(UseDefaultTitleRendering)
 
         this.register(SimplifySmallText)
         this.register(TextSimplificationThreshold)

--- a/packages/klighd-core/src/views-rendering.tsx
+++ b/packages/klighd-core/src/views-rendering.tsx
@@ -31,6 +31,8 @@ import { SKGraphModelRenderer } from './skgraph-model-renderer'
 import {
     Arc,
     HorizontalAlignment,
+    isContainerRendering,
+    isKText,
     KArc,
     KChildArea,
     KContainerRendering,
@@ -1306,7 +1308,56 @@ export function getRendering(
         return undefined
     }
 
+    // look for a title rendering; if none exists, label the first (dfs) rendering as the title rendering.
+    const useSmartZoom =
+        context.renderOptionsRegistry.getValueOrDefault(UseSmartZoom) && context.targetKind !== 'hidden'
+    // only call this on the root rendering of KNodes
+    if (useSmartZoom && parent instanceof SKNode && parent.data.includes(kRendering)) {
+        establishTitleRendering(kRendering)
+    }
+
     return renderKRendering(kRendering, parent, propagatedStyles, context, childOfNodeTitle)
+}
+
+export function establishTitleRendering(rendering: KRendering): KRendering | undefined {
+    let titleRendering = dfs(rendering, isNodeTitle)
+    if (titleRendering !== undefined) {
+        return titleRendering
+    }
+    titleRendering = dfs(rendering, isKText)
+    if (titleRendering !== undefined) {
+        titleRendering.properties['klighd.isNodeTitle'] = true
+    }
+
+    return undefined
+}
+
+/**
+ * Checks if the given rendering has the `klighd.isNodeTitle` set to `true` in its properties.
+ */
+export function isNodeTitle(rendering: KRendering): boolean {
+    return rendering.properties['klighd.isNodeTitle'] === true
+}
+
+/**
+ * Returns the first rendering that matches the `condition` via depth first search.
+ * @param rendering The rendering to search in. The condition will also be checked on this rendering itself.
+ * @param condition The condition to check
+ * @returns The first matching element, or `undefined` if none exist.
+ */
+export function dfs(rendering: KRendering, condition: (r: KRendering) => boolean): KRendering | undefined {
+    if (condition(rendering)) {
+        return rendering
+    }
+    if (isContainerRendering(rendering)) {
+        for (const childRendering of rendering.children) {
+            const childResult = dfs(childRendering, condition)
+            if (childResult !== undefined) {
+                return childResult
+            }
+        }
+    }
+    return undefined
 }
 
 /**

--- a/packages/klighd-core/src/views-rendering.tsx
+++ b/packages/klighd-core/src/views-rendering.tsx
@@ -25,6 +25,7 @@ import {
     SimplifySmallText,
     TextSimplificationThreshold,
     TitleScalingFactor,
+    UseDefaultTitleRendering,
     UseSmartZoom,
 } from './options/render-options-registry'
 import { SKGraphModelRenderer } from './skgraph-model-renderer'
@@ -1311,8 +1312,9 @@ export function getRendering(
     // look for a title rendering; if none exists, label the first (dfs) rendering as the title rendering.
     const useSmartZoom =
         context.renderOptionsRegistry.getValueOrDefault(UseSmartZoom) && context.targetKind !== 'hidden'
+    const useDefaultTitleRendering = context.renderOptionsRegistry.getValueOrDefault(UseDefaultTitleRendering)
     // only call this on the root rendering of KNodes
-    if (useSmartZoom && parent instanceof SKNode && parent.data.includes(kRendering)) {
+    if (useSmartZoom && useDefaultTitleRendering && parent instanceof SKNode && parent.data.includes(kRendering)) {
         establishTitleRendering(kRendering)
     }
 
@@ -1465,8 +1467,14 @@ export function renderKRendering(
             const originalX = renderingOffsets.x
             const originalY = renderingOffsets.y
 
-            const maxScaleX = parentBounds.width / originalWidth
-            const maxScaleY = parentBounds.height / originalHeight
+            let maxScaleX = parentBounds.width / originalWidth
+            let maxScaleY = parentBounds.height / originalHeight
+            // If scaling up is not really worthwile, don't bother to scale at all.
+            if (maxScaleX < 1.2 || maxScaleY < 1.2) {
+                maxScaleX = 1
+                maxScaleY = 1
+            }
+
             // Don't let scalingfactor get too big.
             let scalingFactor = Math.min(maxScaleX, maxScaleY, maxScale)
             // Make sure we never scale down.
@@ -1533,7 +1541,7 @@ export function renderKRendering(
                 useSmartZoom &&
                 (kRendering.properties['klighd.isNodeTitle'] as boolean) &&
                 ((parent instanceof SKNode && isFullDetail(parent, context) && !isProxy) || scaleProxy) &&
-                ((maxScale > 1 && !isProxy) || scaleProxy) &&
+                ((scalingFactor > 1 && !isProxy) || scaleProxy) &&
                 // Don't draw if the rendering is an empty KText
                 (kRendering.type !== K_TEXT || (kRendering as KText).text !== '')
             ) {


### PR DESCRIPTION
- This adds a "default title rendering" option that automatically picks the first text rendering in each rendering as the title rendering to be scaled by smart zoom.
- Changes the full detail relative threshold to .1
- do not scale up title renderings that cannot be sensibly scaled up by more than 20%