### PR TITLE
fix a div by zero issue with the new animation

### DIFF
--- a/packages/klighd-core/src/new-viewport-command.ts
+++ b/packages/klighd-core/src/new-viewport-command.ts
@@ -124,9 +124,17 @@ export class NewViewportAnimation extends ViewportAnimation {
         const interimZoomDiff = 1 - oldZoom / tweenZoom
         const zoomDiff = 1 - oldZoom / newZoom
 
-        this.element.scroll = {
-            x: oldX + (interimZoomDiff * (newX - oldX)) / zoomDiff,
-            y: oldY + (interimZoomDiff * (newY - oldY)) / zoomDiff,
+        if (zoomDiff === 0) {
+            // No zoom diff: avoid calculation of 0/0 and use linear formula
+            this.element.scroll = {
+                x: (1 - t) * oldX + t * newX,
+                y: (1 - t) * oldY + t * newY,
+            }
+        } else {
+            this.element.scroll = {
+                x: oldX + (interimZoomDiff * (newX - oldX)) / zoomDiff,
+                y: oldY + (interimZoomDiff * (newY - oldY)) / zoomDiff,
+            }
         }
         return context.root
     }


### PR DESCRIPTION
I previously did not take into account that animations can also not alter the zoom level, causing a NaN values because of a attempted calculation of 0/0 in the viewport animation.
This fixes that issue and falls back to linear scroll interpolation without taking the zoom level into account if the zoom has not changed.