### PR TITLE
Add Quick Action for Diagram Search to the Sidebar

### DIFF
--- a/packages/klighd-core/src/options/option-models.ts
+++ b/packages/klighd-core/src/options/option-models.ts
@@ -39,7 +39,7 @@ export interface RenderOption extends Option {
 }
 
 /** Type for available quick actions. */
-export type PossibleQuickAction = 'center' | 'fit' | 'layout' | 'refresh' | 'export' | 'pin-sidebar'
+export type PossibleQuickAction = 'search' | 'center' | 'fit' | 'layout' | 'refresh' | 'export' | 'pin-sidebar'
 
 export interface QuickActionOption {
     key: PossibleQuickAction

--- a/packages/klighd-core/src/options/render-options-registry.ts
+++ b/packages/klighd-core/src/options/render-options-registry.ts
@@ -47,6 +47,29 @@ export class PinSidebarOption implements RenderOption {
 }
 
 /**
+ * Whether the search bar is visible or not.
+ */
+export class SearchBarVisibleOption implements RenderOption {
+    static readonly ID: string = 'search-bar-visible'
+
+    static readonly NAME: string = 'Search Bar Visible'
+
+    static readonly DEFAULT: boolean = false
+
+    readonly id: string = SearchBarVisibleOption.ID
+
+    readonly name: string = SearchBarVisibleOption.NAME
+
+    readonly type: TransformationOptionType = TransformationOptionType.CHECK
+
+    readonly initialValue: boolean = SearchBarVisibleOption.DEFAULT
+
+    currentValue = SearchBarVisibleOption.DEFAULT
+
+    debug = true
+}
+
+/**
  * Resize the diagram to fit the viewport if it is redrawn after a model update
  * or a viewport resize.
  * This has to have the same id as the corresponding FitToScreenAction.
@@ -539,6 +562,7 @@ export class RenderOptionsRegistry extends Registry {
         this.register(DebugOptions)
         this.register(ResizeToFit)
         this.register(PinSidebarOption)
+        this.register(SearchBarVisibleOption)
 
         this.register(AnimateGoToBookmark)
 

--- a/packages/klighd-core/src/search-bar/searchbar-actions.ts
+++ b/packages/klighd-core/src/search-bar/searchbar-actions.ts
@@ -65,17 +65,23 @@ export interface ToggleSearchBarAction extends Action {
     kind: typeof ToggleSearchBarAction.KIND
     state?: 'show' | 'hide'
     panel: SearchBarPanel
+    focusSearch: boolean
 }
 
 // eslint-disable-next-line no-redeclare
 export namespace ToggleSearchBarAction {
     export const KIND = 'toggleSearchBar'
 
-    export function create(panel: SearchBarPanel, state?: 'show' | 'hide'): ToggleSearchBarAction {
+    export function create(
+        panel: SearchBarPanel,
+        state?: 'show' | 'hide',
+        focusSearch: boolean = true
+    ): ToggleSearchBarAction {
         return {
             kind: KIND,
             state,
             panel,
+            focusSearch,
         }
     }
 
@@ -202,7 +208,7 @@ export class SearchBarActionHandler implements IActionHandler {
 
     private HIGHLIGHT_MAIN_MATCH: number = 1
 
-    private panel: SearchBarPanel
+    @inject(SearchBarPanel) private panel: SearchBarPanel
 
     private modelChanged: boolean = false
 
@@ -245,22 +251,24 @@ export class SearchBarActionHandler implements IActionHandler {
             return
         }
 
-        if (!SearchBarActionHandler.currentModel) return
-
-        const modelId = SearchBarActionHandler.currentModel?.id
-
         if (ToggleSearchBarAction.isThisAction(action)) {
-            if (!this.panel) {
-                this.panel = action.panel
-            }
-
             const newVisible = action.state === 'show'
 
             if (this.panel.isVisible !== newVisible) {
                 this.panel.changeVisibility(newVisible)
                 this.panel.update()
             }
-        } else if (ClearHighlightsAction.isThisAction(action)) {
+            if (newVisible && action.focusSearch) {
+                this.panel.focus()
+            }
+            return
+        }
+
+        if (!SearchBarActionHandler.currentModel) return
+
+        const modelId = SearchBarActionHandler.currentModel?.id
+
+        if (ClearHighlightsAction.isThisAction(action)) {
             /* Handle ClearHighlightsActions */
             this.removeHighlights(action.results)
             // make changes visible

--- a/packages/klighd-core/src/search-bar/searchbar-panel.tsx
+++ b/packages/klighd-core/src/search-bar/searchbar-panel.tsx
@@ -22,9 +22,11 @@ import { VNode } from 'snabbdom'
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { html, IActionDispatcher, TYPES } from 'sprotty'
 import { FitToScreenAction, SelectAction } from 'sprotty-protocol'
-import { ClearHighlightsAction, SearchAction, ToggleSearchBarAction, UpdateHighlightsAction } from './searchbar-actions'
+import { ClearHighlightsAction, SearchAction, UpdateHighlightsAction } from './searchbar-actions'
 import { SearchBar } from './searchbar'
 import { SearchResult } from './search-results'
+import { SetRenderOptionAction } from '../options/actions'
+import { SearchBarVisibleOption } from '../options/render-options-registry'
 
 @injectable()
 export class SearchBarPanel {
@@ -154,6 +156,12 @@ export class SearchBarPanel {
         return this.lastActiveIndex
     }
 
+    public focus(): void {
+        setTimeout(() => {
+            this.mainInput?.select()
+        }, 0)
+    }
+
     /**
      * Updates anything that changes, when the search bar is toggled
      * @param vis the new visibility
@@ -168,12 +176,9 @@ export class SearchBarPanel {
         if (vis) {
             document.addEventListener('keydown', this.handleKeyEvent)
             setTimeout(() => {
-                if (this.mainInput) {
-                    this.mainInput.select()
-                    if (vis !== oldVis) {
-                        // trigger search only if search wasn't already open
-                        this.performSearch()
-                    }
+                if (this.mainInput && vis !== oldVis) {
+                    // trigger search only if search wasn't already open
+                    this.performSearch()
                 }
             }, 0)
         } else {
@@ -609,7 +614,7 @@ export class SearchBarPanel {
             this.searched = false
             this.tagInputVisible = false
             this.lastActiveIndex = this.selectedIndex
-            this.actionDispatcher.dispatch(ToggleSearchBarAction.create(this, 'hide'))
+            this.actionDispatcher.dispatch(SetRenderOptionAction.create(SearchBarVisibleOption.ID, false))
         }
     }
 

--- a/packages/klighd-core/src/search-bar/searchbar.tsx
+++ b/packages/klighd-core/src/search-bar/searchbar.tsx
@@ -25,6 +25,9 @@ import { VNode } from 'snabbdom'
 import { AbstractUIExtension, html, IActionDispatcher, Patcher, PatcherProvider, TYPES } from 'sprotty'
 import { RetrieveTagsAction, ShowSearchBarAction, ToggleSearchBarAction } from './searchbar-actions'
 import { SearchBarPanel } from './searchbar-panel'
+import { SetRenderOptionAction } from '../options/actions'
+import { RenderOptionsRegistry, SearchBarVisibleOption } from '../options/render-options-registry'
+import { DISymbol } from '../di.symbols'
 
 /**
  * A search bar extension that lets you search for text in a diagram.
@@ -41,6 +44,8 @@ export class SearchBar extends AbstractUIExtension {
 
     @inject(TYPES.IActionDispatcher) private actionDispatcher: IActionDispatcher
 
+    @inject(DISymbol.RenderOptionsRegistry) private renderOptionsRegistry: RenderOptionsRegistry
+
     @inject(SearchBarPanel) private panel: SearchBarPanel
 
     @postConstruct()
@@ -52,6 +57,8 @@ export class SearchBar extends AbstractUIExtension {
         this.panel.setVisibilityChangeCallback(() => {
             this.update()
         })
+        this.renderOptionsRegistry.onChange(() => this.syncVisibilityWithRenderOption())
+        this.syncVisibilityWithRenderOption(false)
 
         setTimeout(() => {
             this.actionDispatcher.dispatch(ShowSearchBarAction.create())
@@ -99,10 +106,28 @@ export class SearchBar extends AbstractUIExtension {
         window.addEventListener('keydown', (event) => {
             if ((event.ctrlKey || event.metaKey) && !event.altKey && event.key.toLowerCase() === 'f') {
                 event.preventDefault()
-                this.panel.changeVisibility(true)
-                this.actionDispatcher.dispatch(ToggleSearchBarAction.create(this.panel, 'show'))
-                this.actionDispatcher.dispatch(RetrieveTagsAction.create())
+                if (this.panel.isVisible) {
+                    this.panel.focus()
+                    return
+                }
+
+                this.actionDispatcher.dispatch(SetRenderOptionAction.create(SearchBarVisibleOption.ID, true))
             }
         })
+    }
+
+    private syncVisibilityWithRenderOption(focusSearch: boolean = true): void {
+        const newState = this.renderOptionsRegistry.getValueOrDefault(SearchBarVisibleOption)
+        if (this.panel.isVisible === newState) return
+
+        if (newState) {
+            this.actionDispatcher.dispatch(ShowSearchBarAction.create())
+        }
+
+        this.actionDispatcher.dispatch(ToggleSearchBarAction.create(this.panel, newState ? 'show' : 'hide', focusSearch))
+
+        if (newState) {
+            this.actionDispatcher.dispatch(RetrieveTagsAction.create())
+        }
     }
 }

--- a/packages/klighd-core/src/search-bar/searchbar.tsx
+++ b/packages/klighd-core/src/search-bar/searchbar.tsx
@@ -124,7 +124,9 @@ export class SearchBar extends AbstractUIExtension {
             this.actionDispatcher.dispatch(ShowSearchBarAction.create())
         }
 
-        this.actionDispatcher.dispatch(ToggleSearchBarAction.create(this.panel, newState ? 'show' : 'hide', focusSearch))
+        this.actionDispatcher.dispatch(
+            ToggleSearchBarAction.create(this.panel, newState ? 'show' : 'hide', focusSearch)
+        )
 
         if (newState) {
             this.actionDispatcher.dispatch(RetrieveTagsAction.create())

--- a/packages/klighd-core/src/sidebar/sidebar-panel.tsx
+++ b/packages/klighd-core/src/sidebar/sidebar-panel.tsx
@@ -123,8 +123,8 @@ export abstract class SidebarPanel implements ISidebarPanel {
             {
                 key: 'search',
                 title: this.renderOptionsRegistry.getValueOrDefault(SearchBarVisibleOption)
-                    ? 'Hide search'
-                    : 'Search diagram',
+                    ? 'Hide search (Ctrl+F)'
+                    : 'Search diagram (Ctrl+F)',
                 iconId: 'search',
                 action: SetRenderOptionAction.create(
                     SearchBarVisibleOption.ID,

--- a/packages/klighd-core/src/sidebar/sidebar-panel.tsx
+++ b/packages/klighd-core/src/sidebar/sidebar-panel.tsx
@@ -26,7 +26,12 @@ import { DISymbol } from '../di.symbols'
 import { FeatherIcon } from '../feather-icons-snabbdom/feather-icons-snabbdom'
 import { SetRenderOptionAction } from '../options/actions'
 import { PossibleQuickAction, QuickActionOption } from '../options/option-models'
-import { PinSidebarOption, RenderOptionsRegistry, ResizeToFit } from '../options/render-options-registry'
+import {
+    PinSidebarOption,
+    RenderOptionsRegistry,
+    ResizeToFit,
+    SearchBarVisibleOption,
+} from '../options/render-options-registry'
 
 /**
  * A sidebar panel provides content that is shown by the sidebar.
@@ -115,6 +120,18 @@ export abstract class SidebarPanel implements ISidebarPanel {
      */
     protected assignQuickActions(): void {
         this.quickActions = [
+            {
+                key: 'search',
+                title: this.renderOptionsRegistry.getValueOrDefault(SearchBarVisibleOption)
+                    ? 'Hide search'
+                    : 'Search diagram',
+                iconId: 'search',
+                action: SetRenderOptionAction.create(
+                    SearchBarVisibleOption.ID,
+                    !this.renderOptionsRegistry.getValueOrDefault(SearchBarVisibleOption)
+                ),
+                state: this.renderOptionsRegistry.getValue(SearchBarVisibleOption),
+            },
             {
                 key: 'center',
                 title: 'Center diagram',


### PR DESCRIPTION
This change adds a second way to toggle the diagram search functionality (next to the existing `CTRL+F` / `Cmd+F` shortcut).

**Screenshot**:

<img width="773" height="286" alt="image" src="https://github.com/user-attachments/assets/e1edf7b2-76a7-4ab1-8b55-fce53011fce7" />
